### PR TITLE
[찬민]로그인 페이지 ui 뼈대잡기, api폴더구조, 라우트 폴더구조 잡기

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,4 @@
+//로그인 api
+export async function POST() {
+  return Response.json({ message: "Login endpoint" });
+}

--- a/src/app/api/signup/route.ts
+++ b/src/app/api/signup/route.ts
@@ -1,0 +1,4 @@
+//회원가입 api
+export async function POST() {
+  return Response.json({ message: "Signup endpoint" });
+}

--- a/src/app/assets/Assets.tsx
+++ b/src/app/assets/Assets.tsx
@@ -1,9 +1,0 @@
-// Assets를 모으는 컴포넌트입니다
-
-export default function Assets() {
-  return (
-    <div>
-      <h1>Assets 컴포넌트</h1>
-    </div>
-  );
-}

--- a/src/app/components/Components.tsx
+++ b/src/app/components/Components.tsx
@@ -1,9 +1,0 @@
-// Components를 모으는 컴포넌트입니다
-
-export default function Components() {
-  return (
-    <div>
-      <h1>Components 컴포넌트</h1>
-    </div>
-  );
-}

--- a/src/app/data/Data.tsx
+++ b/src/app/data/Data.tsx
@@ -1,9 +1,0 @@
-// Data를 모으는 컴포넌트입니다
-
-export default function Data() {
-  return (
-    <div>
-      <h1>Data 컴포넌트</h1>
-    </div>
-  );
-}

--- a/src/app/hooks/Hooks.tsx
+++ b/src/app/hooks/Hooks.tsx
@@ -1,9 +1,0 @@
-// Hooks를 모으는 컴포넌트입니다
-
-export default function Hooks() {
-  return (
-    <div>
-      <h1>Hooks 컴포넌트</h1>
-    </div>
-  );
-}

--- a/src/app/layout/Layout.tsx
+++ b/src/app/layout/Layout.tsx
@@ -1,9 +1,0 @@
-// Layout을 모으는 컴포넌트입니다
-
-export default function Layout() {
-  return (
-    <div>
-      <h1>Layout 컴포넌트</h1>
-    </div>
-  );
-}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,5 @@
+import { redirect } from "next/navigation";
+
 export default function Home() {
-  return (
-    <>
-      <div className="flex flex-col items-center justify-center text-[50px] text-blue-500">찬민 테스트</div>
-      <div className="text-[20px]">테일윈드 3.4버전 입니다</div>
-      <div className="text-[20px]">폰트 컬러 변경되는지 확인헤주세요</div>
-    </>
-  );
+  redirect("/page/login");
 }

--- a/src/app/page/login/_components/LoginUi.tsx
+++ b/src/app/page/login/_components/LoginUi.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function LoginUi() {
+  const router = useRouter();
+
+  const handleSignupClick = () => {
+    router.push("/page/signup");
+  };
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50">
+      {/* 로고 이미지 가져와서 붙여넣기 */}
+      <div className="w-[248px] h-[45px] bg-[#EA3C12] rounded mb-8"></div>
+
+      <div className="w-[350px] mb-4">
+        <span className="block text-gray-700 text-sm font-medium mb-2">이메일</span>
+        <input
+          type="email"
+          placeholder="입력"
+          className="w-full h-[58px] border border-gray-300 rounded-[8px] px-4 text-gray-500 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#EA3C12] focus:border-transparent"
+        />
+      </div>
+
+      <div className="w-[350px] mb-6">
+        <span className="block text-gray-700 text-sm font-medium mb-2">비밀번호</span>
+        <input
+          type="password"
+          placeholder="입력"
+          className="w-full h-[58px] border border-gray-300 rounded-[8px] px-4 text-gray-500 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#EA3C12] focus:border-transparent"
+        />
+      </div>
+
+      <button className="w-[350px] h-[48px] bg-[#EA3C12] text-white rounded-[8px] font-medium hover:bg-[#d6340f] transition-colors duration-200 mb-4">
+        로그인 하기
+      </button>
+
+      <div className="w-[350px] h-[19px] text-center">
+        <span className="text-gray-600 text-sm">회원이 아니신가요? </span>
+        <button onClick={handleSignupClick} className="text-[#EA3C12] hover:underline font-medium text-sm">
+          회원가입 하기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page/login/page.tsx
+++ b/src/app/page/login/page.tsx
@@ -1,0 +1,5 @@
+import LoginUi from "./_components/LoginUi";
+
+export default function LoginPage() {
+  return <LoginUi />;
+}

--- a/src/app/page/signup/_components/SignupUi.tsx
+++ b/src/app/page/signup/_components/SignupUi.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function SignupUi() {
+  const router = useRouter();
+
+  const handleLoginClick = () => {
+    router.push("/page/login");
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50">
+      <h1 className="text-2xl font-bold text-gray-700 mb-4">개발중입니다</h1>
+      <button onClick={handleLoginClick} className="text-[#EA3C12] hover:underline font-medium">
+        로그인으로 돌아가기
+      </button>
+    </div>
+  );
+}

--- a/src/app/page/signup/page.tsx
+++ b/src/app/page/signup/page.tsx
@@ -1,0 +1,5 @@
+import SignupUi from "./_components/SignupUi";
+
+export default function SignupPage() {
+  return <SignupUi />;
+}

--- a/src/app/pages/Pages.tsx
+++ b/src/app/pages/Pages.tsx
@@ -1,9 +1,0 @@
-// Pages를 모으는 컴포넌트입니다
-
-export default function Pages() {
-  return (
-    <div>
-      <h1>Pages 컴포넌트</h1>
-    </div>
-  );
-}

--- a/src/app/styles/Styles.tsx
+++ b/src/app/styles/Styles.tsx
@@ -1,9 +1,0 @@
-// Styles를 모으는 컴포넌트입니다
-
-export default function Styles() {
-  return (
-    <div>
-      <h1>Styles 컴포넌트</h1>
-    </div>
-  );
-}

--- a/src/app/tests/Tests.tsx
+++ b/src/app/tests/Tests.tsx
@@ -1,9 +1,0 @@
-// Tests를 모으는 컴포넌트입니다
-
-export default function Tests() {
-  return (
-    <div>
-      <h1>Tests 컴포넌트</h1>
-    </div>
-  );
-}

--- a/src/app/types/Types.tsx
+++ b/src/app/types/Types.tsx
@@ -1,9 +1,0 @@
-// Types를 모으는 컴포넌트입니다
-
-export default function Types() {
-  return (
-    <div>
-      <h1>Types 컴포넌트</h1>
-    </div>
-  );
-}

--- a/src/app/utils/Utils.tsx
+++ b/src/app/utils/Utils.tsx
@@ -1,9 +1,0 @@
-// Utils를 모으는 컴포넌트입니다
-
-export default function Utils() {
-  return (
-    <div>
-      <h1>Utils 컴포넌트</h1>
-    </div>
-  );
-}


### PR DESCRIPTION
시작할 때 로그인 화면에서 움직여야 보기가 좀 편할 것 같아서 로그인 페이지 뼈대만 잡아놨습니다
최상위 page를 /page/login으로 리다이렉트 해놓아서 run dev하면 바로 로그인 뼈대잡힌 페이지가 나옵니다

폴더가 많아지긴 하겠지만 각자 사용하실 api관련된 내용은 app 폴더 안에 api폴더에다 추가해서 사용하면 좋을것같습니다
마찬가지로 라우터도 padd 폴더 / page폴더 / 각자 해당하는 페이지(이 폴더 이름이 라우트 주소 *찡긋*)를 만들어서 사용할까요

프로젝트 시작하면서 버튼이나 인풋 창 등을 components폴더로 빼놓는 작업을 먼저 해놓겠습니다 
(반응형 구현시 크기가 바뀌어야 하는 모달창은 신중히 고민해볼게요)

