### PR TITLE
[원선] feat : TailwindCSS 컬러 팔레트, 폰트 크기 추가

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,50 @@ module.exports = {
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        black: "#111322",
+        white: "#FFFFFF",
+        gray: {
+          50: "#7D7986",
+          40: "#A4A1AA",
+          30: "#CBC9CF",
+          20: "#E5E4E7",
+          10: "#F2F2F3",
+          5: "#FAFAFA",
+        },
+        red: {
+          40: "#FF4040",
+          30: "#FF8D72",
+          20: "#FFAF9B",
+          10: "#FFEBE7",
+        },
+        blue: {
+          20: "#0080FF",
+          10: "#CCE6FF",
+        },
+        green: {
+          20: "#20A81E",
+          10: "#D4F7D4",
+        },
+        yellow: "#FEE500",
+      },
+      screens: {
+        mobile: { max: "375px" },
+        tablet: { min: "744px", max: "1439px" },
+        desktop: { min: "1440px" },
+      },
+      fontSize: {
+        "body-1-regular": ["16px", { lineHeight: "26px", fontWeight: "400" }],
+        "body-2-regular": ["14px", { lineHeight: "22px", fontWeight: "400" }],
+        "body-1-bold": ["16px", { lineHeight: "20px", fontWeight: "700" }],
+        "body-2-bold": ["14px", { lineHeight: "100%", fontWeight: "700" }],
+        caption: ["12px", { lineHeight: "16px", fontWeight: "400" }],
+        h1: ["28px", { lineHeight: "100%", fontWeight: "700" }],
+        h2: ["24px", { lineHeight: "100%", fontWeight: "700" }],
+        h3: ["30px", { lineHeight: "100%", fontWeight: "700" }],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
# TailwindCSS 컬러 팔레트, 폰트 크기 추가

## 작업 내용

피그마 시안을 통해 커스텀 컬러와 폰트 크기를 추가했습니다.

## 참고사항

먼저 테스트 해보시고 안되시거나, 아니면 폰트네임 변경이 필요하시면 말씀해주세요

바로 수정하겠습니다.