### PR TITLE
[추가] button 컴포넌트 구현

### DIFF
--- a/src/components/common/button/index.tsx
+++ b/src/components/common/button/index.tsx
@@ -39,7 +39,7 @@ const Button: React.FC<ButtonProps> = ({
   // variant별 스타일
   const VARIANT_STYLES = {
     primary: "bg-primary-20 text-white hover:bg-primary-10 focus:ring-primary-20",
-    outlined: "bg-white text-primary border border-primary-20 hover:bg-red-10 focus:ring-primary-20",
+    outlined: "bg-white text-primary-20 border border-primary-20 hover:bg-red-10 focus:ring-primary-20",
     blue: "bg-white text-blue-20 border border-blue-20 hover:bg-blue-10 focus:ring-blue-20",
   };
 

--- a/src/components/common/button/index.tsx
+++ b/src/components/common/button/index.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "outlined" | "blue";
+  size?: "large" | "medium" | "small";
+  children: React.ReactNode;
+}
+
+/**
+ * THE-JULGE 프로젝트 공용 직사각형 버튼 컴포넌트
+ *
+ * @param {Object} props - Button 컴포넌트 props
+ * @param {"primary"|"outlined"|"blue"} [props.variant="primary"] - 버튼 스타일 지정 (primary: 빨간색? solid, outlined: 빨간색 테두리, blue: 파란색 테두리)
+ * @param {"large"|"medium"|"small"} [props.size="large"] - 버튼 높이 지정, 너비는 부모에서 제어 (large: 48px, medium: PC 48px/Mobile 37px, small: 37px)
+ * @param {string} [props.className=""] - 기존 className 전달 또는 새로 추가할 className (너비 제어 등)
+ * @param {React.ReactNode} props.children - 버튼 내용(텍스트)
+ * @param {Object} [restProps] - 버튼에 전달되는 추가 속성(onClick, disabled, type 등)
+ *
+ */
+
+const Button: React.FC<ButtonProps> = ({
+  variant = "primary",
+  size = "large",
+  className = "",
+  children,
+  ...restProps
+}) => {
+  // 공통 스타일
+  const BASE_STYLES =
+    "font-medium rounded-md transition-all duration-200 flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:bg-gray-40 disabled:text-white disabled:border-gray-40 disabled:cursor-not-allowed";
+
+  // 높이별 스타일
+  const SIZE_STYLES = {
+    large: "h-12 text-body-1-bold",
+    medium: "h-[37px] text-body-2-bold md:h-12 md:text-body-1-bold",
+    small: "h-[37px] text-body-2-bold",
+  };
+
+  // variant별 스타일
+  const VARIANT_STYLES = {
+    primary: "bg-primary-20 text-white hover:bg-primary-10 focus:ring-primary-20",
+    outlined: "bg-white text-primary border border-primary-20 hover:bg-red-10 focus:ring-primary-20",
+    blue: "bg-white text-blue-20 border border-blue-20 hover:bg-blue-10 focus:ring-blue-20",
+  };
+
+  const finalClasses = [BASE_STYLES, SIZE_STYLES[size], VARIANT_STYLES[variant], className].filter(Boolean).join(" ");
+
+  return (
+    <button className={finalClasses} {...restProps}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,10 @@ module.exports = {
       colors: {
         black: "#111322",
         white: "#FFFFFF",
+        primary: {
+          20: "#EA3C12",
+          10: "#ec502a",
+        },
         gray: {
           50: "#7D7986",
           40: "#A4A1AA",


### PR DESCRIPTION
## button 컴포넌트 구현

### Variant (스타일)
- `primary` - 기본 버튼 색상 진한 주황색 + 흰색 텍스트 (기본값)
- `outlined` - 진한 주황색 테두리 + 흰색 배경 + 진한 주황색 텍스트
- `blue` - 파란색 테두리 + 흰색 배경 + 파란색 텍스트 (색만 다르고 outlined랑 동일)

### Size (높이 기준)
- `large` - pc,mo = 48px (기본값)
- `medium` - pc = 48px, mo = 37px
- `small` - pc,mo = 37px

기본 사용
```
import Button from "@/components/common/button";

<Button>로그인</Button>
```

스타일 적용
```
<Button variant="primary" size="large">
  로그인 하기
</Button>
```

부모로 너비 제어
```
<div className="w-[350px]">
  <Button>로그인</Button>
</div>
```
className으로 직접 제어
```
<Button className="w-full">전체 너비 버튼</Button>
<Button className="w-32">고정 너비 버튼</Button>
```

`disabled` 속성을 추가하면 자동으로 disabled 디자인 적용됩니다.

디자인 시안상 버튼의 높이가 1 ~ 5px 정도 차이가 나는 경우가 있는데 통일해도 괜찮을 것 같아서 크게 3가지 사이즈로 나눴습니다.
반응형 적용됩니다.(사이즈,폰트) 다만 너비는 직접 주셔야함
하지만 페이지를 만들었을때 어색해 보일 수도 있을 것 같아서 그런 경우 알려주시면 수정해보겠습니다~