### PR TITLE
[원선] Header GNB(사장, 알바) 기능 임시 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { AuthProvider } from "@/contexts/AuthContext";
 import Header from "@/components/common/header/Header";
 import Footer from "@/components/common/footer/Footer";
+import DevTool from "@/constants/DevTool";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -16,9 +18,12 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <Header />
-        {children}
-        <Footer />
+        <AuthProvider>
+          <Header />
+          <DevTool />
+          {children}
+          <Footer />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/components/common/gnb/CommonGnb.tsx
+++ b/src/components/common/gnb/CommonGnb.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useAuth } from "@/contexts/AuthContext";
+import GuestMenu from "./GuestMenu";
+import EmployeeMenu from "./EmployeeMenu";
+import EmployerMenu from "./EmployerMenu";
+
+export default function CommonGnb() {
+  const { user, userType } = useAuth();
+
+  // 게스트 (비로그인)
+  if (!user) {
+    return <GuestMenu />;
+  }
+
+  // 알바 유저
+  if (userType === "employee") {
+    return <EmployeeMenu />;
+  }
+
+  // 사장 유저
+  if (userType === "employer") {
+    return <EmployerMenu />;
+  }
+  return null;
+}

--- a/src/components/common/gnb/EmployeeMenu.tsx
+++ b/src/components/common/gnb/EmployeeMenu.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import Image from "next/image";
+
+const EmployeeMenu = () => {
+  return (
+    <nav className="flex items-center gap-10 text-body-1-bold">
+      <Link href="/profile">내 프로필</Link>
+      <Link href="/">로그아웃</Link>
+      <button>
+        <Image src="/inactive.svg" width={24} height={24} alt="알림 아이콘" />
+      </button>
+    </nav>
+  );
+};
+
+export default EmployeeMenu;

--- a/src/components/common/gnb/EmployerMenu.tsx
+++ b/src/components/common/gnb/EmployerMenu.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import Image from "next/image";
+
+const EmployerMenu = () => {
+  return (
+    <nav className="flex items-center gap-10 text-body-1-bold">
+      <Link href="/shop">내 가게</Link>
+      <Link href="/">로그아웃</Link>
+      <button>
+        <Image src="/inactive.svg" width={24} height={24} alt="알림 아이콘" />
+      </button>
+    </nav>
+  );
+};
+
+export default EmployerMenu;

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import Search from "@/components/common/gnb/Search";
-import GuestMenu from "@/components/common/gnb/GuestMenu";
+import CommonGnb from "../gnb/CommonGnb";
 
 export default function Header() {
   return (
@@ -11,7 +11,7 @@ export default function Header() {
           <Image src="/logo.svg" width={112} height={40} alt="더 줄게 로고" />
         </Link>
         <Search />
-        <GuestMenu />
+        <CommonGnb />
       </div>
     </header>
   );

--- a/src/constants/DevTool.tsx
+++ b/src/constants/DevTool.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+
+export default function DevTool() {
+  const searchParams = useSearchParams();
+  const { loginAsMockEmployee, loginAsMockEmployer, logout } = useAuth();
+
+  useEffect(() => {
+    const devMode = searchParams.get("dev");
+
+    if (devMode) {
+      switch (devMode) {
+        case "employee":
+          loginAsMockEmployee();
+          console.log("알바 GNB");
+          break;
+        case "employer":
+          loginAsMockEmployer();
+          console.log("사장 GNB");
+          break;
+        case "logout":
+          logout();
+          console.log("로그아웃");
+          break;
+      }
+
+      const url = new URL(window.location.href);
+      url.searchParams.delete("dev");
+      window.history.replaceState({}, "", url.toString());
+    }
+  }, [searchParams, loginAsMockEmployee, loginAsMockEmployer, logout]);
+
+  return null;
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,66 @@
+// TODO: 로그인 페이지 완성 후 실제 API 연동 추가 필요
+
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+import { User, UserType } from "@/types/user";
+import { mockEmployeeUser, mockEmployerUser } from "@/lib/MockUsers";
+
+interface AuthContextType {
+  user: User | null; // 현재 로그인한 유저 정보
+  userType: UserType; // 유저 타입 (employee | employer | null)
+  logout: () => void; // 로그아웃
+  loginAsMockEmployee: () => void; // Mock 알바 유저
+  loginAsMockEmployer: () => void; // Mock 사장 유저
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+
+  // 로그아웃
+
+  const logout = () => {
+    localStorage.removeItem("mockUserType");
+    setUser(null);
+  };
+
+  // Mock 로그인
+  const loginAsMockEmployee = () => {
+    setUser(mockEmployeeUser);
+    localStorage.setItem("mockUserType", "employee");
+  };
+
+  const loginAsMockEmployer = () => {
+    setUser(mockEmployerUser);
+    localStorage.setItem("mockUserType", "employer");
+  };
+
+  // 유저 타입 계산 (employee | employer | null)
+  const userType: UserType = user?.type || null;
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        userType,
+        logout,
+        loginAsMockEmployee,
+        loginAsMockEmployer,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+
+  if (context === undefined) {
+    throw new Error("useAuth는 AuthProvider 내부에서만 사용할 수 있습니다.");
+  }
+
+  return context;
+}

--- a/src/lib/MockUsers.ts
+++ b/src/lib/MockUsers.ts
@@ -1,0 +1,40 @@
+import { User, Shop } from "@/types/user";
+
+// Mock 가게 데이터
+const mockShop: Shop = {
+  item: {
+    id: "shop-001",
+    name: "스타벅스 강남점",
+    category: "카페",
+    address1: "서울특별시 강남구",
+    address2: "테헤란로 123",
+    description: "강남역 근처 스타벅스입니다.",
+    imageUrl: "https://via.placeholder.com/400x300",
+    originalHourlyPay: 12000,
+  },
+  href: "/shops/shop-001",
+};
+
+// Mock 알바 유저
+export const mockEmployeeUser: User = {
+  id: "user-001",
+  email: "alba@example.com",
+  type: "employee",
+  name: "김알바",
+  phone: "010-1234-5678",
+  address: "서울특별시 강남구",
+  bio: "성실하고 책임감 있는 알바생입니다.",
+  shop: null,
+};
+
+// Mock 사장 유저
+export const mockEmployerUser: User = {
+  id: "user-002",
+  email: "owner@example.com",
+  type: "employer",
+  name: "이사장",
+  phone: "010-9876-5432",
+  address: "서울특별시 강남구",
+  bio: "좋은 환경의 가게를 운영하고 있습니다.",
+  shop: mockShop,
+};

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,39 @@
+export type UserType = "employer" | "employee" | null;
+
+// 가게 정보
+export interface Shop {
+  item: {
+    id: string;
+    name: string; // 가게 이름
+    category: string; //  가게 분류
+    address1: string; // 주소
+    address2: string; // 상세 주소
+    description: string; // 가게 설명
+    imageUrl: string; // 가게 이미지
+    originalHourlyPay: number; //  기존 시급
+  };
+  href: string; // 프로필URL
+}
+
+// 유저 정보 (내 정보 조회)
+export interface User {
+  id: string;
+  email: string; // 로그인 이메일
+  type: "employer" | "employee"; // 사장 | 알바
+  name?: string; // 이름
+  phone?: string; // 연락처
+  address?: string; // 선호 지역
+  bio?: string; // 자기 소개
+  shop?: Shop | null; // 사장 유저
+}
+
+export interface LoginResponse {
+  item: {
+    token: string;
+    user: {
+      item: User;
+      href: string;
+    };
+  };
+  links: [];
+}


### PR DESCRIPTION
# 개요
* Header GNB 사장, 알바 분류 후 임시 구현

# 주요 변경 사항

- `CommonGnb.tsx` 생성
	- 타입별 GNB 적용
- `MockUsers.ts`  생성
	- 임시 데이터 관리
- `EmployeeMenu` 생성
	- 알바 GNB
- `EmployerMenu` 생성
	- 사장 GNB 
- `type/user.ts` 생성
	- `User`, `Shop`, `LoginResponse` 타입 분리
- `authContext.tsx` 생성
	- 인증 상태 관리
- `DevTool.tsx` 생성
	- URL Parms로 임시적으로 GNB 변환 기능 구현

# 시연 영상

### 로그인 URL이 기본URL로 되어 있어 `/login`뒤에 이어 붙여주시면 됩니다.

알바유저 로그인 상태
*  http://localhost:3000/login?dev=employee

https://github.com/user-attachments/assets/e6463e1b-d651-4c35-82bc-120df902af07


사장유저 로그인 상태
*  http://localhost:3000/login?dev=employer

https://github.com/user-attachments/assets/b2afa4f3-6c69-4d5a-be9c-45fc4f16a443




# 참고 사항

Header의 로그인과 회원가입 GNB는 로그인기능과 회원가입 기능이 어느정도 구현이 되면 이어서 다시 구현을 해나갈 생각입니다. 우선적으로 Mock 데이터로 임시 Use를 만들어 GNB가 변환이 가능케 했습니다.

GNB에 알림 기능을 확인하기 위해 로그인된 상태는 URL Parms로 확인이 가능합니다.

