### PR TITLE
[추가] 내 프로필 상세 페이지 구현 및 테스트용 모달 추가

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -6,10 +6,10 @@ export default function ProfilePage() {
     <div className="flex flex-col min-h-screen bg-white">
       <main className="flex-1 flex flex-col items-center">
         <div className="w-full max-w-[60.25rem] mx-auto px-5 tablet:px-8 mt-[116px] mb-[118px]">
-          {/* ✅ 타이틀 왼쪽 정렬 */}
+          {/* 타이틀 */}
           <h1 className="text-h2 text-black mb-[40px] text-left">내 프로필</h1>
 
-          {/* ✅ 박스 중앙 정렬 */}
+          {/* 안내 박스 */}
           <section
             className="
               w-[964px]

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,36 @@
+import Button from "@/components/common/button";
+import Link from "next/link";
+
+export default function ProfilePage() {
+  return (
+    <div className="flex flex-col min-h-screen bg-white">
+      <main className="flex-1 flex flex-col items-center">
+        <div className="w-full max-w-[60.25rem] mx-auto px-5 tablet:px-8 mt-[116px] mb-[118px]">
+          {/* ✅ 타이틀 왼쪽 정렬 */}
+          <h1 className="text-h2 text-black mb-[40px] text-left">내 프로필</h1>
+
+          {/* ✅ 박스 중앙 정렬 */}
+          <section
+            className="
+              w-[964px]
+              border border-gray-20 rounded-[12px]
+              py-[60px] px-[24px]
+              flex flex-col items-center justify-center gap-[24px]
+              mx-auto
+            "
+          >
+            <p className="text-body-1-regular text-black text-center w-[916px]">
+              내 프로필을 등록하고 원하는 가게에 지원해 보세요.
+            </p>
+
+            <Link href="/profile/register" className="inline-block">
+              <Button variant="primary" size="large" className="w-[346px] h-[47px] rounded-[6px]">
+                내 프로필 등록하기
+              </Button>
+            </Link>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/profile/register/page.tsx
+++ b/src/app/profile/register/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import Button from "@/components/common/button";
+import Modal from "@/components/common/modal/CommonModal";
+import { REGION_OPTIONS } from "@/constants/options";
+
+export default function ProfileRegisterPage() {
+  const [form, setForm] = useState({
+    name: "",
+    phone: "",
+    region: "",
+    intro: "",
+  });
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsModalOpen(true);
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen bg-white">
+      <main className="flex-1 max-w-[60.25rem] mx-auto px-5 tablet:px-8 mt-[116px] mb-[118px]">
+        <h1 className="text-h2 text-black mb-[40px] text-left">내 프로필</h1>
+
+        <form
+          onSubmit={handleSubmit}
+          className="w-[964px] mx-auto border border-gray-20 rounded-[12px] py-[60px] px-[24px] flex flex-col gap-[24px] bg-white"
+        >
+          {/* 이름 / 연락처 / 지역 */}
+          <div className="grid grid-cols-3 gap-[24px]">
+            <div className="flex flex-col">
+              <label className="text-body-1-bold text-black mb-2">이름*</label>
+              <input
+                type="text"
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+                placeholder="입력"
+                required
+                className="border border-gray-20 rounded-md p-3 focus:outline-none"
+              />
+            </div>
+
+            <div className="flex flex-col">
+              <label className="text-body-1-bold text-black mb-2">연락처*</label>
+              <input
+                type="tel"
+                name="phone"
+                value={form.phone}
+                onChange={handleChange}
+                placeholder="입력"
+                required
+                className="border border-gray-20 rounded-md p-3 focus:outline-none"
+              />
+            </div>
+
+            <div className="flex flex-col">
+              <label className="text-body-1-bold text-black mb-2">선호 지역</label>
+              <select
+                name="region"
+                value={form.region}
+                onChange={handleChange}
+                className="border border-gray-20 rounded-md p-3 bg-white"
+              >
+                <option value="">선택</option>
+                {REGION_OPTIONS.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* 소개 */}
+          <div>
+            <label className="text-body-1-bold text-black mb-2 block">소개</label>
+            <textarea
+              name="intro"
+              value={form.intro}
+              onChange={handleChange}
+              placeholder="입력"
+              rows={4}
+              className="border border-gray-20 rounded-md p-3 w-full resize-none focus:outline-none"
+            />
+          </div>
+
+          {/* 등록 버튼 */}
+          <Button type="submit" variant="primary" size="large" className="w-[346px] h-[47px] rounded-[6px] mx-auto">
+            등록하기
+          </Button>
+        </form>
+      </main>
+
+      {/* 등록 완료 모달 */}
+      {isModalOpen && (
+        <Modal onClose={() => setIsModalOpen(false)}>
+          <p className="text-lg font-semibold mb-6">등록이 완료되었습니다.</p>
+          <Button
+            variant="primary"
+            size="medium"
+            className="w-full"
+            onClick={() => (window.location.href = "/profile")}
+          >
+            확인
+          </Button>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/modal/CommonModal.tsx
+++ b/src/components/common/modal/CommonModal.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface ModalProps {
+  children: React.ReactNode;
+  onClose: () => void;
+}
+
+export default function Modal({ children, onClose }: ModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 bg-black bg-opacity-40 flex items-center justify-center">
+      <div className="bg-white p-8 rounded-xl shadow-lg w-[320px] text-center relative">
+        {children}
+        <button onClick={onClose} className="absolute top-3 right-3 text-gray-500 hover:text-black text-xl">
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/modal/CommonModal.tsx
+++ b/src/components/common/modal/CommonModal.tsx
@@ -1,3 +1,5 @@
+/* 테스트 모달입니다. */
+
 import React from "react";
 
 interface ModalProps {
@@ -17,3 +19,5 @@ export default function Modal({ children, onClose }: ModalProps) {
     </div>
   );
 }
+
+/* 테스트 모달입니다. */


### PR DESCRIPTION
##  Feature: 내 프로필 상세 페이지 구현 및 테스트용 모달 추가

### 작업 개요
- **내 프로필 상세 페이지(`src/app/profile/page.tsx`)** 신규 구현
- **피그마 디자인 가이드**(964px 카드, 346px 버튼, padding·radius·컬러 등) 기준 반영
- **테스트용 모달 코드** 작성 및 적용

- 추후 `/profile/register` 페이지 연동 및 DB 데이터 연결 예정

<img width="1899" height="1462" alt="제목 없음" src="https://github.com/user-attachments/assets/30a04e2c-4e93-4052-a784-ce84eede552c" />
