### PR TITLE
[추가] 가게 등록 / 관리 컴포넌트 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,15 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        // TODO: API 연동시 이미지URL 와일드 카드 변경
+        protocol: "https",
+        hostname: "**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/components/owner/EmptyNotice.tsx
+++ b/src/components/owner/EmptyNotice.tsx
@@ -1,0 +1,28 @@
+import { useRouter } from "next/navigation";
+import Button from "../common/button";
+
+export const EmptyNotice = () => {
+  const router = useRouter();
+
+  const handleRegisterNotice = () => {
+    router.push("owner/register-notice");
+  };
+
+  return (
+    <section className="w-full h-full pt-[60] pb-[120px] bg-gray-5">
+      <div className="max-w-[964px] w-full mx-auto">
+        <div className="mb-6">
+          <h2 className="text-h1">등록한 공고</h2>
+        </div>
+        <div className="w-full border border-gray-20 rounded-xl">
+          <div className="flex flex-col items-center gap-6 py-[60px]">
+            <span className="text-body-1-regular">공고를 등록해 보세요.</span>
+            <Button variant="primary" className="max-w-[346px] w-full" size="large" onClick={handleRegisterNotice}>
+              공고 등록하기
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/components/owner/EmptyShop.tsx
+++ b/src/components/owner/EmptyShop.tsx
@@ -1,0 +1,25 @@
+import { useRouter } from "next/navigation";
+import Button from "../common/button";
+
+export const EmptyShop = () => {
+  const router = useRouter();
+
+  const handleRegisterShop = () => {
+    router.push("/owner/register-shop");
+  };
+
+  return (
+    <section className="w-full h-full">
+      <div className="max-w-[964px] w-full mx-auto">
+        <div className="w-full border border-gray-20 rounded-xl">
+          <div className="flex flex-col items-center gap-6 py-[60px]">
+            <span className="text-body-1-regular">내 가게를 소개하고 공고도 등록해 보세요.</span>
+            <Button variant="primary" className="max-w-[346px] w-full" size="large" onClick={handleRegisterShop}>
+              가게 등록하기
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/components/owner/ShopInfo.tsx
+++ b/src/components/owner/ShopInfo.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import Button from "../common/button";
+import { Shop } from "@/types/user";
+
+interface ShopInfoProps {
+  shop: Shop;
+}
+
+export const ShopInfo = ({ shop }: ShopInfoProps) => {
+  const router = useRouter();
+
+  const handleEdit = () => {
+    router.push(`/owner/edit-shop/${shop.item.id}`);
+  };
+
+  const handleRegisterNotice = () => {
+    router.push("/owner/register-notice");
+  };
+  return (
+    <section className="w-full max-w-[964px] my-[60px] mx-auto bg-white">
+      <div className=" w-full">
+        <div className="mb-6">
+          <h2 className="text-h1">내 가게</h2>
+        </div>
+        <div className="flex w-full bg-red-10 p-6 gap-[30px] rounded-xl">
+          {/* 가게 이미지 */}
+          <div className="relative w-[539px] h-[309px]">
+            <Image src={shop.item.imageUrl} alt={shop.item.name} fill className="object-cover rounded-xl" priority />
+          </div>
+
+          {/* 가게 정보 */}
+          <div className="w-[346px] flex flex-col justify-between gap-3 grow-0">
+            {/* 가게 타이틀 */}
+            <div>
+              <span className="text-body-1-bold text-primary-10">{shop.item.category}</span>
+              <h2 className="text-h1">{shop.item.name}</h2>
+            </div>
+            {/* 주소 */}
+            <div className="flex gap-1.5 text-body-1-regular ">
+              <Image
+                src="/Location.svg"
+                width={20}
+                height={20}
+                alt="주소 아이콘"
+                style={{ width: "20px", height: "20px" }}
+              />
+              <span className="text-gray-50">{shop.item.address1}</span>
+            </div>
+            {/* 가게 정보 */}
+            <div className="grow text-body-1-regular">
+              <p>{shop.item.description}</p>
+            </div>
+            {/* 버튼 */}
+            <div className="w-full flex gap-2">
+              <div className="w-full">
+                <Button variant="outlined" className=" w-full" size="large" onClick={handleEdit}>
+                  편집하기
+                </Button>
+              </div>
+              <div className="w-full">
+                <Button variant="primary" className=" w-full" size="large" onClick={handleRegisterNotice}>
+                  공고 등록하기
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};


### PR DESCRIPTION
# 개요

사장 대시보드에서 사용될 **가게 등록, 가게 정보, 공고 등록** 컴포넌트들을 구현했습니다.

# 추가/변경 사항

- `src/components/owner/EmptyShop.tsx` - 가게 등록하기
- `src/components/owner/ShopInfo.tsx` - 가게 상세 정보 관리
- `src/components/owner/EmptyNotice.tsx` - 공고 등록하기
- `next.config.ts` - 원격 이미지 최적화

| 가게 등록하기 | 가게 상세 정보 관리 | 공고 등록하기 |
| --- | --- | --- |
|<img width="1440" height="733" alt="스크린샷 2025-10-15 오후 6 07 12" src="https://github.com/user-attachments/assets/012c0ab5-2574-470a-83a7-321af452b071" />|<img width="1440" height="601" alt="스크린샷 2025-10-15 오후 7 04 07" src="https://github.com/user-attachments/assets/0b25082a-d914-45eb-9cc9-f53c5cc17568" />|<img width="1440" height="555" alt="스크린샷 2025-10-15 오후 7 04 20" src="https://github.com/user-attachments/assets/4d85bd2e-7cc1-4be8-b09b-c10322284b5b" />|


# 참고사항

현재 가게 등록, 가게 상세 정보, 공고 등록 컴포넌트로만 구현했습니다.
페이지를 여러 개를 구현할까 했지만 조건부 렌더링으로 바꾸어서 구현해볼까 합니다.
