### PR TITLE
[철종] Completed writing the common modal file

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,104 @@
-import { redirect } from "next/navigation";
+// src/app/page.tsx
+"use client";
+
+import React, { useState, FormEvent, ChangeEvent } from "react";
+import CommonModal from "@/components/common/modal/CommonModal";
+import formStyles from "@/components/common/styles/CommonModal.module.css";
+
+// 음식점 데이터 타입 정의
+interface StoreData {
+  storeName: string;
+  category: string;
+  address: string;
+  phone?: string;
+}
 
 export default function Home() {
-  redirect("/login");
+  // 모달이 열렸는지 닫혔는지 관리
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 폼 데이터 관리
+  const [formData, setFormData] = useState<StoreData>({
+    storeName: "",
+    category: "",
+    address: "",
+    phone: "",
+  });
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log("입점 등록 정보:", formData);
+    alert(`${formData.storeName} 가게 등록이 완료되었습니다.`);
+    setIsModalOpen(false);
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <main className="flex-1 flex flex-col items-center p-8">
+        <h1 className="text-h2 text-black mb-8">가맹점 관리 페이지</h1>
+
+        {/* 가게 등록 버튼 */}
+        <div className="flex justify-center w-full my-8">
+          <button onClick={() => setIsModalOpen(true)} className={`${formStyles.submitButton} w-[346px]`}>
+            내 가게 등록하기
+          </button>
+        </div>
+
+        {/* CommonModal 컴포넌트를 사용 */}
+        <CommonModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title="내 가게 등록">
+          <form onSubmit={handleSubmit}>
+            <div className={formStyles.formGroup}>
+              <label htmlFor="storeName">가게 이름</label>
+              <input
+                type="text"
+                id="storeName"
+                name="storeName"
+                value={formData.storeName}
+                onChange={handleInputChange}
+                required
+              />
+            </div>
+            <div className={formStyles.formGroup}>
+              <label htmlFor="category">카테고리</label>
+              <input
+                type="text"
+                id="category"
+                name="category"
+                placeholder="예: 한식, 양식, 중식, 일식, 카페 등"
+                value={formData.category}
+                onChange={handleInputChange}
+                required
+              />
+            </div>
+            <div className={formStyles.formGroup}>
+              <label htmlFor="address">가게 주소</label>
+              <input
+                type="text"
+                id="address"
+                name="address"
+                value={formData.address}
+                onChange={handleInputChange}
+                required
+              />
+            </div>
+            <div className={formStyles.formGroup}>
+              <label htmlFor="phone">연락처</label>
+              <input type="tel" id="phone" name="phone" onChange={handleInputChange} />
+            </div>
+            {/* 버튼 텍스트 */}
+            <div className="flex justify-center w-full mt-6">
+              <button type="submit" variant="primary" size="large" className={`${formStyles.submitButton} w-full`}>
+                등록 완료
+              </button>
+            </div>
+          </form>
+        </CommonModal>
+      </main>
+    </div>
+  );
 }

--- a/src/app/page_01.tsx
+++ b/src/app/page_01.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Home() {
+  redirect("/login");
+}

--- a/src/components/common/modal/CommonModal.tsx
+++ b/src/components/common/modal/CommonModal.tsx
@@ -1,23 +1,42 @@
 /* 테스트 모달입니다. */
+"use client";
 
 import React from "react";
+import styles from "../styles/CommonModal.module.css";
 
+// 컴포넌트가 받을 props 타입
 interface ModalProps {
-  children: React.ReactNode;
+  isOpen: boolean;
   onClose: () => void;
+  title: string;
+  children: React.ReactNode; // 모달 내부에 표시될 모든 React 요소
 }
 
-export default function Modal({ children, onClose }: ModalProps) {
+const CommonModal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+  // isOpen이 false이면 아무것도 렌더링하지 않음
+  if (!isOpen) {
+    return null;
+  }
+
   return (
-    <div className="fixed inset-0 z-50 bg-black bg-opacity-40 flex items-center justify-center">
-      <div className="bg-white p-8 rounded-xl shadow-lg w-[320px] text-center relative">
-        {children}
-        <button onClick={onClose} className="absolute top-3 right-3 text-gray-500 hover:text-black text-xl">
-          ×
-        </button>
+    // 모달배경(오버레이) 클릭시 CLOSE
+    <div className={styles.modalOverlay} onClick={onClose}>
+      {/* 실제 모달 창 (클릭해도 동작않함) */}
+      <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h2>{title}</h2>
+          <button onClick={onClose} className={styles.closeButton}>
+            &times;
+          </button>
+        </div>
+        <div className={styles.modalBody}>
+          {children} {/* 부모에게서 받은 컨텐츠를 여기에 보여줘요! */}
+        </div>
       </div>
     </div>
   );
-}
+};
+
+export default CommonModal;
 
 /* 테스트 모달입니다. */

--- a/src/components/common/modal/CommonModal_00.tsx
+++ b/src/components/common/modal/CommonModal_00.tsx
@@ -1,0 +1,23 @@
+/* 테스트 모달입니다. */
+
+import React from "react";
+
+interface ModalProps {
+  children: React.ReactNode;
+  onClose: () => void;
+}
+
+export default function Modal({ children, onClose }: ModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 bg-black bg-opacity-40 flex items-center justify-center">
+      <div className="bg-white p-8 rounded-xl shadow-lg w-[320px] text-center relative">
+        {children}
+        <button onClick={onClose} className="absolute top-3 right-3 text-gray-500 hover:text-black text-xl">
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* 테스트 모달입니다. */

--- a/src/components/common/styles/CommonModal.module.css
+++ b/src/components/common/styles/CommonModal.module.css
@@ -1,0 +1,110 @@
+/* src/components/common/styles/CommonModal.module.css */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modalContent {
+  background-color: white;
+  padding: 2.5rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  border: 1px solid #eaeaea;
+  width: 90%;
+  max-width: 550px;
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #eaeaea;
+  padding-bottom: 1rem;
+  margin-bottom: 2rem;
+}
+.modalHeader h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #2c3e50;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  font-size: 2.2rem;
+  cursor: pointer;
+  color: #95a5a6;
+  transition: color 0.2s;
+}
+.closeButton:hover {
+  color: #2c3e50;
+}
+
+.modalBody {
+  /* 컨텐츠 영역에 필요한 스타일 추가 */
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(30px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+/* 아래는 폼스타일 예시*/
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.formGroup label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.formGroup input {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.formGroup input:focus {
+  outline: none;
+  border-color: #ff4112;
+  box-shadow: 0 0 0 3px rgba(255, 65, 18, 0.15);
+}
+
+.submitButton {
+  margin-top: 1rem;
+  padding: 0.9rem;
+  background-color: #ff4112;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.submitButton:hover {
+  background-color: #e03000;
+}


### PR DESCRIPTION
**1. ## Description**

프로젝트 전반에서 사용할 수 있는 공동모달(CommonModal) UI 컴포넌트를 구현 

**2. ## Key Changes**

- **공동의 기본형 모달구현**: `CommonModal.tsx` 파일에 모달의 기본 레이아웃과 상태 관리 추가
- **CSS**: `CommonModal.module.css` 파일을 이용해 CSS Modules로 스타일 적용
- **Props 기반 제어**: 모달의 제목(title), 내용(children), 닫기 함수(onClose)를 Props로 받아 동적 기능 구현 
- **테스트 페이지 파일 추가**: `page_01.tsx` 파일[원선님 작성]을 공동 모달파일/ 테스트용으로 동작 활용

**3. ## Screenshots**
<img width="816" height="581" alt="20251016_the-julge_011" src="https://github.com/user-attachments/assets/84df047c-931f-4f10-9dfb-8abb172f3089" />

**4. ## To Reviewers**
- 모달 컴포넌트의 사용성을 높이기 위한 Props 설계가 적절한지 리뷰 부탁드립니다.
- 스타일 코드를 더 개선할 부분이 있을지 확인 부탁합니다.
- 미완성된 부분이 있습니다. Footer의 간격이 너무 넓고 스크롤이 쓸데없이 넓게 잡혔습니다. 곧 수정토록 하겠습니다.
- 테일윈드를 사용하다가 잘 안되어서 테일윈드를 사용을 못했습니다.  반응형 구현시 가능 토록 고려하겠습니다. ㅠㅠ
- Toast 부분의 문제도 곧 수정해서 올리 도록 하겠습니다.
- 그리고 예상시간보다 늦게 올려서 죄송합니다. 많이 부족하다보니 실수와 착오가 많이 생깁니다. ㅠㅠ