### PR TITLE
[추가] 공고 목록 컴포넌트 구현

### DIFF
--- a/src/components/owner/EmptyNotice.tsx
+++ b/src/components/owner/EmptyNotice.tsx
@@ -1,28 +1,19 @@
-import { useRouter } from "next/navigation";
-import Button from "../common/button";
+import Link from "next/link";
+import Button from "@/components/common/button";
 
 export const EmptyNotice = () => {
-  const router = useRouter();
-
-  const handleRegisterNotice = () => {
-    router.push("owner/register-notice");
-  };
-
   return (
-    <section className="w-full h-full pt-[60] pb-[120px] bg-gray-5">
-      <div className="max-w-[964px] w-full mx-auto">
-        <div className="mb-6">
-          <h2 className="text-h1">등록한 공고</h2>
-        </div>
-        <div className="w-full border border-gray-20 rounded-xl">
-          <div className="flex flex-col items-center gap-6 py-[60px]">
-            <span className="text-body-1-regular">공고를 등록해 보세요.</span>
-            <Button variant="primary" className="max-w-[346px] w-full" size="large" onClick={handleRegisterNotice}>
+    <div className="max-w-[964px] w-full mx-auto">
+      <div className="w-full border border-gray-20 rounded-xl">
+        <div className="flex flex-col items-center gap-6 py-[60px]">
+          <span className="text-body-1-regular">공고를 등록해 보세요.</span>
+          <Link href={"owner/register-notice"} className="max-w-[346px] w-full">
+            <Button variant="primary" className="w-full" size="large">
               공고 등록하기
             </Button>
-          </div>
+          </Link>
         </div>
       </div>
-    </section>
+    </div>
   );
 };

--- a/src/components/owner/EmptyShop.tsx
+++ b/src/components/owner/EmptyShop.tsx
@@ -1,22 +1,18 @@
-import { useRouter } from "next/navigation";
-import Button from "../common/button";
+import Link from "next/link";
+import Button from "@/components/common/button";
 
 export const EmptyShop = () => {
-  const router = useRouter();
-
-  const handleRegisterShop = () => {
-    router.push("/owner/register-shop");
-  };
-
   return (
-    <section className="w-full h-full">
+    <section className="w-full">
       <div className="max-w-[964px] w-full mx-auto">
         <div className="w-full border border-gray-20 rounded-xl">
           <div className="flex flex-col items-center gap-6 py-[60px]">
             <span className="text-body-1-regular">내 가게를 소개하고 공고도 등록해 보세요.</span>
-            <Button variant="primary" className="max-w-[346px] w-full" size="large" onClick={handleRegisterShop}>
-              가게 등록하기
-            </Button>
+            <Link href={"/owner/register-shop"} className="max-w-[346px] w-full">
+              <Button variant="primary" className="w-full" size="large">
+                가게 등록하기
+              </Button>
+            </Link>
           </div>
         </div>
       </div>

--- a/src/components/owner/NoticeList.tsx
+++ b/src/components/owner/NoticeList.tsx
@@ -1,0 +1,23 @@
+import { useRouter } from "next/navigation";
+import { PostData } from "@/types/post";
+import PostCard from "../common/post/PostCard";
+
+interface NoticeListProps {
+  notices: PostData[];
+}
+
+export const NoticeList = ({ notices }: NoticeListProps) => {
+  const router = useRouter();
+
+  const handleNoticeClick = (notice: PostData) => {
+    router.push(`/owner/notice/${notice.id}`);
+  };
+
+  return (
+    <div className="max-w-[964px] w-full mx-auto grid grid-cols-2 md:grid-cols-3 gap-4">
+      {notices.map(notice => (
+        <PostCard key={notice.id} post={notice} onClick={() => handleNoticeClick(notice)} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/owner/ShopInfo.tsx
+++ b/src/components/owner/ShopInfo.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import Button from "../common/button";
 import { Shop } from "@/types/user";
 
@@ -10,15 +10,6 @@ interface ShopInfoProps {
 }
 
 export const ShopInfo = ({ shop }: ShopInfoProps) => {
-  const router = useRouter();
-
-  const handleEdit = () => {
-    router.push(`/owner/edit-shop/${shop.item.id}`);
-  };
-
-  const handleRegisterNotice = () => {
-    router.push("/owner/register-notice");
-  };
   return (
     <section className="w-full max-w-[964px] my-[60px] mx-auto bg-white">
       <div className=" w-full">
@@ -56,14 +47,18 @@ export const ShopInfo = ({ shop }: ShopInfoProps) => {
             {/* 버튼 */}
             <div className="w-full flex gap-2">
               <div className="w-full">
-                <Button variant="outlined" className=" w-full" size="large" onClick={handleEdit}>
-                  편집하기
-                </Button>
+                <Link href={`/owner/edit-shop/${shop.item.id}`}>
+                  <Button variant="outlined" className=" w-full" size="large">
+                    편집하기
+                  </Button>
+                </Link>
               </div>
               <div className="w-full">
-                <Button variant="primary" className=" w-full" size="large" onClick={handleRegisterNotice}>
-                  공고 등록하기
-                </Button>
+                <Link href={"/owner/register-notice"}>
+                  <Button variant="primary" className=" w-full" size="large">
+                    공고 등록하기
+                  </Button>
+                </Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
/# 개요

사장 대시보드에서 사용될 내가 등록한 공고 목록 컴포넌트 구현했습니다.
중간에 피드백 받은 Link 컴포넌트를 적용했습니다.

# 추가/변경 사항

- `src/components/owner/NoticeList.tsx` - 등록한 공고 목록

<img width="1398" height="651" alt="스크린샷 2025-10-16 오후 7 37 16" src="https://github.com/user-attachments/assets/70e418c4-3378-4e77-9627-2ee8f296e6ca" />


변경
1. `src/components/owner/EmptyNotice.tsx`
2. `src/components/owner/EmptyShop.tsx`
3. `src/components/owner/ShopInfo.tsx`

router -> Link로 변경

# 참고사항

로그인 API가 연동이 되어 Header에서 유저 타입마다 GNB가 바뀌도록 먼저 기능을 구현하고, owner 페이지를 API 연동해서 올리겠습니다.