### PR TITLE
[추가] 가게 관련 API 추가

### DIFF
--- a/src/api/shop/ShopApi.ts
+++ b/src/api/shop/ShopApi.ts
@@ -1,0 +1,55 @@
+import instance from "../axios";
+import { AxiosError } from "axios";
+import { ShopRequest, ShopResponse } from "@/types/shop";
+
+interface ErrorMessage {
+  message: string;
+}
+
+// POST '/shops' - 가게 등록
+export const postShop = async (body: ShopRequest): Promise<ShopResponse> => {
+  try {
+    const response = await instance.post<ShopResponse>("/shops", body);
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorMessage>; //  에러 타입 명시
+
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error("서버를 연결할 수 없습니다. 인터넷 연결을 확인해주세요.");
+    }
+  }
+};
+
+// GET 'shops/{shop_id}' - 가게 정보 조회
+export const getShop = async (shopId: string): Promise<ShopResponse> => {
+  try {
+    const response = await instance.get<ShopResponse>(`/shops/${shopId}`);
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorMessage>; //  에러 타입 명시
+
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error("서버를 연결할 수 없습니다. 인터넷 연결을 확인해주세요.");
+    }
+  }
+};
+
+//PUT '/shops/{shop_id}' - 가게 정보 수정
+export const putShop = async (shopId: string, body: ShopRequest): Promise<ShopResponse> => {
+  try {
+    const response = await instance.put<ShopResponse>(`/shops/${shopId}`, body);
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorMessage>; //  에러 타입 명시
+
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error("서버를 연결할 수 없습니다. 인터넷 연결을 확인해주세요.");
+    }
+  }
+};

--- a/src/types/links.ts
+++ b/src/types/links.ts
@@ -1,0 +1,6 @@
+export interface LinkInfo {
+  rel: string;
+  description: string;
+  method: string;
+  href: string;
+}

--- a/src/types/shop.ts
+++ b/src/types/shop.ts
@@ -1,0 +1,36 @@
+import { REGION_OPTIONS, CATEGORY_OPTIONS } from "@/constants/options";
+import { User } from "./user";
+import { LinkInfo } from "./links";
+
+export interface ShopItem {
+  id: string;
+  name: string; // 가게 이름
+  category: (typeof CATEGORY_OPTIONS)[number]["value"]; //  가게 분류
+  address1: (typeof REGION_OPTIONS)[number]["value"]; // 주소
+  address2: string; // 상세 주소
+  description: string; // 가게 설명
+  imageUrl: string; // 가게 이미지
+  originalHourlyPay: number; //  기존 시급
+}
+
+export interface ShopInfomation {
+  item: ShopItem;
+  href: string;
+}
+
+// POST '/shops' - 가게 등록 Request
+// PUT '/shops/{shop_id}' - 가게 정보 수정 Request
+export type ShopRequest = Omit<ShopItem, "id">;
+
+// POST '/shops' - 가게 등록 Response
+// GET '/shops/{shop_id}' - 가게 정보 조회 Response
+// PUT '/shops/{shop_id}' - 가게 정보 수정 Response
+export interface ShopResponse {
+  item: ShopItem & {
+    user: {
+      item: User;
+      href: string;
+    };
+  };
+  links: LinkInfo[];
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,19 +1,6 @@
-export type UserType = User["type"] | null;
+import { ShopInfomation } from "./shop";
 
-// 가게 정보
-export interface Shop {
-  item: {
-    id: string;
-    name: string; // 가게 이름
-    category: string; //  가게 분류
-    address1: string; // 주소
-    address2: string; // 상세 주소
-    description: string; // 가게 설명
-    imageUrl: string; // 가게 이미지
-    originalHourlyPay: number; //  기존 시급
-  };
-  href: string; // 프로필URL
-}
+export type UserType = User["type"] | null;
 
 // 유저 정보 (내 정보 조회)
 export interface User {
@@ -24,7 +11,7 @@ export interface User {
   phone?: string; // 연락처
   address?: string; // 선호 지역
   bio?: string; // 자기 소개
-  shop?: Shop | null; // 사장 유저
+  shop?: ShopInfomation | null; // 사장 유저
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
# 개요

Shop 타입 정의을 좀 더 명확하게 바꾸고, 타입 분리를 시켰습니다.
가게 등록(POST), 가게 정보 조회(GET), 가게 정보 수정(PUT) API 파일을 추가하였습니다.

# 추가/변경 사항

## 추가

### `src/types/shop.ts` - Shop 타입 정의 파일
- 타입을 세분화하고, API 응답 스펙 타입(`ShopRequest`, `ShopReponse`)

### `src/types/links.ts` - links 타입 정의 공용 파일
- 리스폰스 마지막 "links": [...] 타입 정의

### `src/api/shop/ShopApi.ts` - 가게 API 파일
- POST, GET, PUT API 연결


## 변경

- `src/types/user.ts` - Shop 타입 분리 
