### PR TITLE
[추가] Jobs page 구현

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -20,12 +20,13 @@ const instance: AxiosInstance = axios.create({
  * 요청 인터셉터: 토큰 자동 추가 및 만료 검증
  * 모든 API 요청에 accessToken을 자동으로 Authorization 헤더에 추가
  * 토큰이 만료되었으면 자동으로 로그아웃 처리
- * 단, 로그인/회원가입 API는 토큰 검증 제외
+ * 단, 로그인/회원가입 API 및 공고 목록 조회는 토큰 검증 제외
  */
 instance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
-    // 로그인/회원가입 API는 토큰 검증 제외
-    const isAuthEndpoint = config.url?.includes("/token") || config.url?.includes("/users");
+    // 로그인/회원가입 API 및 공고 목록 조회는 토큰 검증 제외
+    const isAuthEndpoint =
+      config.url?.includes("/token") || config.url?.includes("/users") || config.url?.includes("/notices");
 
     if (!isAuthEndpoint) {
       // 토큰 유효시간 체크

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -10,6 +10,7 @@ import Button from "@/components/common/button";
 import { SORT_OPTIONS } from "@/constants/options";
 import { convertFilterOptionsToApiParams } from "@/types/filter";
 import { parsePostsResponse } from "@/utils/api";
+import { isPostClosed } from "@/utils/post";
 import axios from "@/api/axios";
 
 const ITEMS_PER_PAGE = 9;
@@ -34,13 +35,6 @@ export default function JobPostsPage() {
     window.addEventListener("resize", checkMobile);
     return () => window.removeEventListener("resize", checkMobile);
   }, []);
-
-  // 마감된 공고 판별 함수
-  const isPostClosed = (post: PostData) => {
-    const startDate = new Date(post.startsAt);
-    const isExpired = new Date() > startDate;
-    return post.closed || isExpired;
-  };
 
   const fetchPosts = async (page: number = 1, filters: FilterOptions = {}, sort: string = "time") => {
     setLoading(true);
@@ -75,7 +69,7 @@ export default function JobPostsPage() {
       const response = await axios.get(url);
       console.log("API 응답:", response.data);
 
-      let allPosts = parsePostsResponse(response.data);
+      const allPosts = parsePostsResponse(response.data);
 
       // 활성 공고를 앞에, 마감 공고를 뒤에 배치
       const activePosts = allPosts.filter((p: PostData) => !isPostClosed(p));
@@ -186,9 +180,7 @@ export default function JobPostsPage() {
           ) : posts.length === 0 ? (
             <div className="col-span-full text-center py-8">공고가 없습니다.</div>
           ) : (
-            (isMobile ? posts.slice(0, 8) : posts).map(post => (
-              <PostCard key={post.id} post={post} onClick={handlePostClick} />
-            ))
+            posts.map(post => <PostCard key={post.id} post={post} onClick={handlePostClick} />)
           )}
         </div>
 

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -24,17 +24,8 @@ export default function JobPostsPage() {
   const [totalItems, setTotalItems] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [isMobile, setIsMobile] = useState(false);
 
   const router = useRouter();
-
-  // 화면 크기 감지
-  useEffect(() => {
-    const checkMobile = () => setIsMobile(window.innerWidth < 1024);
-    checkMobile();
-    window.addEventListener("resize", checkMobile);
-    return () => window.removeEventListener("resize", checkMobile);
-  }, []);
 
   const fetchPosts = async (page: number = 1, filters: FilterOptions = {}, sort: string = "time") => {
     setLoading(true);
@@ -64,10 +55,8 @@ export default function JobPostsPage() {
       params.append("sort", sort);
 
       const url = `/notices?${params.toString()}`;
-      console.log("API 요청 URL:", url);
 
       const response = await axios.get(url);
-      console.log("API 응답:", response.data);
 
       const allPosts = parsePostsResponse(response.data);
 
@@ -84,11 +73,6 @@ export default function JobPostsPage() {
       setPosts(pageItems);
       setTotalItems(response.data.count || sortedAllPosts.length);
     } catch (err) {
-      console.error("API 에러:", err);
-      if (err instanceof Error && "response" in err) {
-        console.error("에러 응답 데이터:", (err as any).response?.data);
-        console.error("에러 상태 코드:", (err as any).response?.status);
-      }
       setError("공고를 불러오는데 실패했습니다.");
     } finally {
       setLoading(false);

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import PostCard, { PostData } from "@/components/common/post/PostCard";
+import CommonPagination from "@/components/common/pagination/CommonPagination";
+import CustomDropdown from "@/components/common/input/Dropdown";
+import DetailFilter, { FilterOptions } from "@/components/common/filter";
+import Button from "@/components/common/button";
+import { SORT_OPTIONS } from "@/constants/options";
+import { convertFilterOptionsToApiParams } from "@/types/filter";
+import { parsePostsResponse } from "@/utils/api";
+import axios from "@/api/axios";
+
+const ITEMS_PER_PAGE = 9;
+
+export default function JobPostsPage() {
+  const [sortOption, setSortOption] = useState(SORT_OPTIONS[0].value);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [appliedFilters, setAppliedFilters] = useState<FilterOptions>({});
+  const [posts, setPosts] = useState<PostData[]>([]);
+  const [totalItems, setTotalItems] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isMobile, setIsMobile] = useState(false);
+
+  const router = useRouter();
+
+  // 화면 크기 감지
+  useEffect(() => {
+    const checkMobile = () => setIsMobile(window.innerWidth < 1024);
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+    return () => window.removeEventListener("resize", checkMobile);
+  }, []);
+
+  // 마감된 공고 판별 함수
+  const isPostClosed = (post: PostData) => {
+    const startDate = new Date(post.startsAt);
+    const isExpired = new Date() > startDate;
+    return post.closed || isExpired;
+  };
+
+  const fetchPosts = async (page: number = 1, filters: FilterOptions = {}, sort: string = "time") => {
+    setLoading(true);
+    setError(null);
+    try {
+      // 전체 데이터를 가져오기 위해 offset=0, limit을 100으로 설정
+      const params = new URLSearchParams();
+      params.append("offset", "0");
+      params.append("limit", "100");
+
+      const apiParams = convertFilterOptionsToApiParams(filters);
+
+      if (apiParams.address?.length) {
+        apiParams.address.forEach(location => {
+          params.append("address", location);
+        });
+      }
+
+      if (apiParams.startsAtGte) {
+        params.append("startsAtGte", apiParams.startsAtGte);
+      }
+
+      if (apiParams.hourlyPayGte) {
+        params.append("hourlyPayGte", String(apiParams.hourlyPayGte));
+      }
+
+      params.append("sort", sort);
+
+      const url = `/notices?${params.toString()}`;
+      console.log("API 요청 URL:", url);
+
+      const response = await axios.get(url);
+      console.log("API 응답:", response.data);
+
+      let allPosts = parsePostsResponse(response.data);
+
+      // 활성 공고를 앞에, 마감 공고를 뒤에 배치
+      const activePosts = allPosts.filter((p: PostData) => !isPostClosed(p));
+      const closedPosts = allPosts.filter((p: PostData) => isPostClosed(p));
+      const sortedAllPosts = [...activePosts, ...closedPosts];
+
+      // 페이지네이션 적용
+      const startIdx = (page - 1) * ITEMS_PER_PAGE;
+      const endIdx = startIdx + ITEMS_PER_PAGE;
+      const pageItems = sortedAllPosts.slice(startIdx, endIdx);
+
+      setPosts(pageItems);
+      setTotalItems(response.data.count || sortedAllPosts.length);
+    } catch (err) {
+      console.error("API 에러:", err);
+      if (err instanceof Error && "response" in err) {
+        console.error("에러 응답 데이터:", (err as any).response?.data);
+        console.error("에러 상태 코드:", (err as any).response?.status);
+      }
+      setError("공고를 불러오는데 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 초기 데이터 로드
+  useEffect(() => {
+    fetchPosts(currentPage, appliedFilters, sortOption);
+  }, [currentPage, appliedFilters, sortOption]);
+
+  const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
+
+  const handleSortChange = (value: string) => {
+    setSortOption(value);
+    setCurrentPage(1);
+  };
+
+  const handleFilterClick = () => {
+    setIsFilterOpen(prev => !prev);
+  };
+
+  const handleFilterClose = () => {
+    setIsFilterOpen(false);
+  };
+
+  const handleFilterApply = (filters: FilterOptions) => {
+    setAppliedFilters(filters);
+    setCurrentPage(1);
+  };
+
+  const handleFilterReset = () => {
+    setAppliedFilters({});
+    setCurrentPage(1);
+  };
+
+  const handlePostClick = (post: PostData) => {
+    // 로그인 상태에 관계없이 상세 페이지로 이동
+    router.push(`/jobs/${post.id}`);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-5">
+      <div className="max-w-[994px] mx-auto px-4 py-8">
+        <div className="mb-8">
+          <div className="flex flex-wrap justify-between items-center">
+            <h1 className="text-h1 font-bold text-black mb-5 sm:mb-0">전체 공고</h1>
+
+            <div className="flex items-center gap-2 relative">
+              <div className="w-[130px]">
+                <CustomDropdown
+                  name="sort"
+                  value={sortOption}
+                  options={SORT_OPTIONS}
+                  onChange={handleSortChange}
+                  buttonClassName="h-[37px]"
+                />
+              </div>
+
+              <Button
+                variant={isFilterOpen ? "primary" : "outlined"}
+                size="small"
+                onClick={handleFilterClick}
+                className="whitespace-nowrap px-6"
+              >
+                상세 필터
+              </Button>
+
+              <DetailFilter
+                isOpen={isFilterOpen}
+                onClose={handleFilterClose}
+                onApply={handleFilterApply}
+                onReset={handleFilterReset}
+                initialFilters={appliedFilters}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 mb-12">
+          {loading ? (
+            <div className="col-span-full text-center py-8">로딩 중...</div>
+          ) : error ? (
+            <div className="col-span-full text-center py-8 text-red-500">{error}</div>
+          ) : posts.length === 0 ? (
+            <div className="col-span-full text-center py-8">공고가 없습니다.</div>
+          ) : (
+            (isMobile ? posts.slice(0, 8) : posts).map(post => (
+              <PostCard key={post.id} post={post} onClick={handlePostClick} />
+            ))
+          )}
+        </div>
+
+        {totalPages > 1 && (
+          <CommonPagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/filter/index.tsx
+++ b/src/components/common/filter/index.tsx
@@ -8,7 +8,6 @@ import Input from "@/components/common/input/Input";
 import { REGION_OPTIONS } from "@/constants/options";
 import { useFilter } from "@/hooks/useFilter";
 import { FilterOptions, DetailFilterProps } from "@/types/filter";
-import { formatDateToString } from "@/utils/date";
 import "react-datepicker/dist/react-datepicker.css";
 
 // 필터 관련 타입들을 re-export (컴포넌트 사용 시 편의성을 위해)
@@ -40,12 +39,7 @@ const DetailFilter: React.FC<DetailFilterProps> = ({ isOpen, onClose, onApply, o
   const { filters, handleFilterChange, handleLocationToggle, resetFilters } = useFilter(initialFilters);
 
   const handleApply = () => {
-    // API 전송을 위해 Date를 string으로 변환
-    const apiFilters = {
-      ...filters,
-      startDate: filters.startDate ? formatDateToString(filters.startDate) : undefined,
-    };
-    onApply(apiFilters as any); // 임시로 any 사용, 나중에 API 타입 정의 시 수정
+    onApply(filters);
     onClose();
   };
 
@@ -119,8 +113,7 @@ const DetailFilter: React.FC<DetailFilterProps> = ({ isOpen, onClose, onApply, o
             )}
           </div>
 
-          {/* 구분선 */}
-          <div className="border-t border-gray-20"></div>
+          <div className="border-t border-gray-20" />
 
           <div>
             <label htmlFor="startDate" className="block text-body-2-regular text-black mb-1">
@@ -130,7 +123,7 @@ const DetailFilter: React.FC<DetailFilterProps> = ({ isOpen, onClose, onApply, o
               <DatePicker
                 id="startDate"
                 selected={filters.startDate}
-                onChange={(date: Date | null) => handleFilterChange("startDate", date || new Date())}
+                onChange={(date: Date | null) => handleFilterChange("startDate", date ?? undefined)}
                 dateFormat="yyyy-MM-dd"
                 className="w-full h-12 px-3 py-2 border border-gray-30 rounded-md text-body-2-regular text-black focus:outline-none focus:ring-2 focus:ring-primary-20 focus:border-transparent"
                 placeholderText="날짜를 선택하세요"
@@ -140,8 +133,7 @@ const DetailFilter: React.FC<DetailFilterProps> = ({ isOpen, onClose, onApply, o
             </div>
           </div>
 
-          {/* 구분선 */}
-          <div className="border-t border-gray-20"></div>
+          <div className="border-t border-gray-20" />
 
           <div>
             <label htmlFor="hourlyWageMin" className="block text-body-2-regular text-black mb-1">

--- a/src/components/common/post/PostCard.tsx
+++ b/src/components/common/post/PostCard.tsx
@@ -20,7 +20,7 @@ export type { PostCardProps, PostData };
 const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
   // 기존 시급 대비 시급 인상률 계산
   const getPayIncreaseRate = (): number => {
-    if (!post.shop.originalHourlyPay) return 0;
+    if (!post.shop?.originalHourlyPay || !post.hourlyPay) return 0;
     return Math.round(((post.hourlyPay - post.shop.originalHourlyPay) / post.shop.originalHourlyPay) * 100);
   };
 
@@ -63,8 +63,8 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
     >
       <div className="relative h-[120px] sm:h-[160px] bg-gray-10 mx-3 sm:mx-4 mt-3 sm:mt-0 rounded-[12px]">
         <Image
-          src={post.shop.imageUrl || "/placeholder-shop.svg"}
-          alt={post.shop.name}
+          src={post.shop?.imageUrl || "/placeholder-shop.svg"}
+          alt={post.shop?.name || "가게 이미지"}
           fill
           className="object-cover rounded-[12px]"
           sizes="(max-width: 640px) 171px, 312px"
@@ -78,7 +78,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
 
       <div className="p-3 sm:p-4 flex flex-col">
         <h3 className={`font-bold truncate text-body-1-bold sm:text-[20px] sm:leading-[100%] ${colorStyle.primary}`}>
-          {post.shop.name}
+          {post.shop?.name}
         </h3>
 
         <div className={`flex items-center gap-1 mt-1 sm:mt-2 ${colorStyle.text}`}>
@@ -105,12 +105,12 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
             height={20}
             className="flex-shrink-0 w-[20px] h-[20px]"
           />
-          <span className="truncate text-caption sm:text-body-2-regular">{post.shop.address1}</span>
+          <span className="truncate text-caption sm:text-body-2-regular">{post.shop?.address1}</span>
         </div>
 
         <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2 mt-4">
           <span className={`font-bold text-[18px] leading-[100%] sm:text-h2 ${colorStyle.primary}`}>
-            {post.hourlyPay.toLocaleString()}원
+            {post.hourlyPay?.toLocaleString() || "0"}원
           </span>
 
           {payIncreaseRate > 0 && !isClosed && (

--- a/src/components/common/post/PostCard.tsx
+++ b/src/components/common/post/PostCard.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import Image from "next/image";
 import { PostCardProps, PostData } from "@/types/post";
 import { formatTime, formatDate } from "@/utils/date";
-import { isPostClosed as checkPostClosed } from "@/utils/post";
+import { isPostClosed } from "@/utils/post";
 
 // 포스트 관련 타입들을 re-export (컴포넌트 사용 시 편의성을 위해)
 export type { PostCardProps, PostData };
@@ -28,10 +28,9 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
   // Date 객체 생성
   const startDate = new Date(post.startsAt);
   const endDate = new Date(startDate.getTime() + post.workhour * 60 * 60 * 1000);
-  const currentDate = new Date();
 
   // 시간 기반 마감 여부 확인
-  const isClosed = checkPostClosed(post);
+  const isClosed = isPostClosed(post);
 
   // 색상 스타일 객체
   const COLOR_STYLES = {

--- a/src/components/common/post/PostCard.tsx
+++ b/src/components/common/post/PostCard.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import Image from "next/image";
 import { PostCardProps, PostData } from "@/types/post";
 import { formatTime, formatDate } from "@/utils/date";
+import { isPostClosed as checkPostClosed } from "@/utils/post";
 
 // 포스트 관련 타입들을 re-export (컴포넌트 사용 시 편의성을 위해)
 export type { PostCardProps, PostData };
@@ -30,8 +31,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
   const currentDate = new Date();
 
   // 시간 기반 마감 여부 확인
-  const isExpired = currentDate > startDate;
-  const isClosed = post.closed || isExpired;
+  const isClosed = checkPostClosed(post);
 
   // 색상 스타일 객체
   const COLOR_STYLES = {

--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -41,8 +41,8 @@ export const CATEGORY_OPTIONS = [
 
 // 정렬 선택지
 export const SORT_OPTIONS = [
-  { label: "마감임박순", value: "deadline" },
-  { label: "시급많은순", value: "highWage" },
-  { label: "가나다순", value: "alphabet" },
-  { label: "최신등록순", value: "recent" },
+  { label: "마감임박순", value: "time" },
+  { label: "시급많은순", value: "pay" },
+  { label: "시간적은순", value: "hour" },
+  { label: "가나다순", value: "shop" },
 ];

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -6,12 +6,19 @@ export interface FilterOptions {
   startDate?: Date; // 시작일 (Date 객체)
 }
 
+// API 변환은 별도 함수로
+export const convertFilterOptionsToApiParams = (filters: FilterOptions) => ({
+  address: filters.location,
+  hourlyPayGte: filters.hourlyWageMin,
+  startsAtGte: filters.startDate ? new Date(filters.startDate.getTime() + 9 * 60 * 60 * 1000).toISOString() : undefined,
+});
+
 // 필터 컴포넌트 Props 인터페이스
 
 export interface DetailFilterProps {
   isOpen: boolean; // 필터 열림 상태
   onClose: () => void; // 필터 닫기 함수
-  onApply: (filters: FilterOptions) => void; // 필터 적용 함수
+  onApply: (filters: FilterOptions) => void; // 필터 적용 함수 (UI 타입)
   onReset: () => void; // 필터 초기화 함수
   initialFilters?: FilterOptions; // 초기 필터 값
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,23 @@
+import { PostData } from "@/types/post";
+
+// 단일 포스트 아이템을 PostData로 변환
+export const transformPostItem = (item: any): PostData => ({
+  id: item.item?.id || item.id,
+  shop: {
+    id: item.item?.shop?.item?.id || item.shop?.id,
+    name: item.item?.shop?.item?.name || item.shop?.name,
+    address1: item.item?.shop?.item?.address1 || item.shop?.address1,
+    imageUrl: item.item?.shop?.item?.imageUrl || item.shop?.imageUrl,
+    originalHourlyPay: item.item?.shop?.item?.originalHourlyPay || item.shop?.originalHourlyPay,
+  },
+  hourlyPay: item.item?.hourlyPay || item.hourlyPay,
+  startsAt: item.item?.startsAt || item.startsAt,
+  workhour: item.item?.workhour || item.workhour,
+  closed: item.item?.closed || item.closed,
+});
+
+// API 응답을 PostData[]로 파싱
+export const parsePostsResponse = (data: any): PostData[] => {
+  const items = data.items || [data];
+  return Array.isArray(items) ? items.map(transformPostItem) : [transformPostItem(data)];
+};

--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -1,0 +1,8 @@
+import { PostData } from "@/types/post";
+
+// 공고 마감 여부 판별 유틸 함수
+export const isPostClosed = (post: PostData): boolean => {
+  const startDate = new Date(post.startsAt);
+  const isExpired = new Date() > startDate;
+  return post.closed || isExpired;
+};


### PR DESCRIPTION
현재 app/Jobs 폴더를 만들어서 페이지 구현해두었습니다.(따로 연결된 곳은 없음)

### 환경변수
`NEXT_PUBLIC_API_URL="https://bootcamp-api.codeit.kr/api/15-6/the-julge"`

---

### 수정
- `options.ts` 의 정렬 옵션 api와 동일하게 수정
- api연동으로 인한 PostCard 컴포넌트, filter 컴포넌트 적용방식 수정
- filter 타입 추가
- `axios.ts` 의 공고 목록 조회(공고 리스트)에 대한 토큰 검증 제외 조건 추가
- PostCard 컴포넌트와 페이지에 동일하게 사용되는 공고 마감여부 판별 유틸 함수 분리
---

### 추가
- `utils/api.ts` 추가 ( api 응답 파싱)
- 공고목록 페이지 추가 `/Jobs`

### 공고 목록 페이지

|PC|태블릿|모바일|
|------|---|---|
|<img width="608" height="678" alt="image" src="https://github.com/user-attachments/assets/d750935c-6a4a-4f80-9399-4b3d5b836392" /><img width="609" height="673" alt="image" src="https://github.com/user-attachments/assets/e0cc49c4-7bdd-4560-97a7-904a33016867" />|<img width="768" height="2192" alt="image" src="https://github.com/user-attachments/assets/e9818d2f-6333-4666-94fa-8adcdf8ddfc1" />|<img width="376" height="1858" alt="image" src="https://github.com/user-attachments/assets/7399ec39-15b9-4b05-b2dc-b02558a4a22b" />|

### 구현 완료
- 반응형 대응 (PC에서는 1줄에 3개의 포스트카드, 모바일에서는 1줄에 2개의 포스트카드)
- 페이지네이션 컴포넌트 적용
- 정렬 적용 (마감임박순, 시급많은순, 시간적은순, 가나다순), 마감공고는 무조건 활성공고의 뒤에 정렬
- 상세 필터 적용 ( 주소1, 날짜, 시급) : 이전 날짜는 선택 불가능

---

### 추가 해야하는 것
- 맞춤 공고는 전체 공고 위에 조건부 렌더링으로 구현 예정 ( 로그인 안한 상태, 로그인한 상태, 로그인했지만 프로필입력 안한 상태(시간관계상 프로필 입력여부는 구현 안될 수 있음))

---

### 수정이 필요할 것 같은 부분
- 임의로 페이지 이름을 Jobs로 했으나 noticelist가 더 직관적일 것 같습니다. 의견이 필요해요.
- 현재 페이지당 9개의 공고를 보여주는데, 모바일에서는 한줄에 2개를 보여주기때문에 마지막 줄에서 어색한 점이 있어요. 제일 간단한 해결책은 보여주는걸 처음부터 6개로 바꾸는것 같아요..