### PR TITLE
[추가] 공고 관련 API 파일 추가

### DIFF
--- a/src/api/alert/AlertsApi.ts
+++ b/src/api/alert/AlertsApi.ts
@@ -1,5 +1,5 @@
-import { AxiosError } from "axios";
 import instance from "../axios";
+import { handleApiError } from "../error/ErrorHandler";
 import { NotificationListResponse, NotificationReadResponse } from "@/types/notification";
 
 interface ErrorMessage {
@@ -18,13 +18,7 @@ export const getAlerts = async (
     });
     return response.data;
   } catch (error) {
-    const axiosError = error as AxiosError<ErrorMessage>; //  에러 타입 명시
-
-    if (axiosError.response) {
-      throw new Error(axiosError.response.data.message);
-    } else {
-      throw new Error("서버에 연결할 수 없습니다. 인터넷 연결을 확인해주세요.");
-    }
+    return handleApiError(error);
   }
 };
 
@@ -34,12 +28,6 @@ export const putAlerts = async (userId: string, alertId: string): Promise<Notifi
     const response = await instance.put(`/users/${userId}/alerts/${alertId}`);
     return response.data;
   } catch (error) {
-    const axiosError = error as AxiosError<ErrorMessage>; //  에러 타입 명시
-
-    if (axiosError.response) {
-      throw new Error(axiosError.response.data.message);
-    } else {
-      throw new Error("서버에 연결할 수 없습니다. 인터넷 연결을 확인해주세요.");
-    }
+    return handleApiError(error);
   }
 };

--- a/src/api/error/ErrorHandler.ts
+++ b/src/api/error/ErrorHandler.ts
@@ -1,0 +1,14 @@
+import { AxiosError } from "axios";
+
+interface ErrorMessage {
+  message: string;
+}
+
+export const handleApiError = (error: unknown): never => {
+  const axiosError = error as AxiosError<ErrorMessage>;
+
+  if (axiosError.response) {
+    throw new Error(axiosError.response.data.message);
+  }
+  throw new Error("서버를 연결할 수 없습니다. 인터넷 연결을 확인해주세요.");
+};

--- a/src/api/error/ErrorHandler.ts
+++ b/src/api/error/ErrorHandler.ts
@@ -7,8 +7,13 @@ interface ErrorMessage {
 export const handleApiError = (error: unknown): never => {
   const axiosError = error as AxiosError<ErrorMessage>;
 
-  if (axiosError.response) {
+  if (axiosError.response?.data?.message) {
     throw new Error(axiosError.response.data.message);
   }
+
+  if (axiosError.message) {
+    throw new Error(axiosError.message);
+  }
+
   throw new Error("서버를 연결할 수 없습니다. 인터넷 연결을 확인해주세요.");
 };

--- a/src/api/notice/NoticeApi.ts
+++ b/src/api/notice/NoticeApi.ts
@@ -1,4 +1,5 @@
 import instance from "@/api/axios";
+import { AxiosError } from "axios";
 import { GetNoticesResponse, GetShopNoticesResponse, NoticeBodyRequst, NoticeShopInfo } from "@/types/notice";
 import { handleApiError } from "../error/ErrorHandler";
 
@@ -69,7 +70,7 @@ export const postShopNotice = async (shopId: string, body: NoticeBodyRequst): Pr
 export const getShopNotice = async (shopId: string, noticeId: string): Promise<GetShopNoticesResponse> => {
   try {
     const response = await instance.get<GetShopNoticesResponse>(`
-            /shops/${shopId}/notices/${noticeId}`);
+            /shops/${shopId}/notices?${noticeId}`);
     return response.data;
   } catch (error) {
     return handleApiError(error);

--- a/src/api/notice/NoticeApi.ts
+++ b/src/api/notice/NoticeApi.ts
@@ -1,0 +1,91 @@
+import instance from "@/api/axios";
+import { GetNoticesResponse, GetShopNoticesResponse, NoticeBodyRequst, NoticeShopInfo } from "@/types/notice";
+import { handleApiError } from "../error/ErrorHandler";
+
+export const getNotices = async (query?: {
+  offset?: number;
+  limit?: number;
+  address?: string[];
+  keyword?: string;
+  startsAtGte?: string;
+  hourlyPayGte?: number;
+  sort?: "time" | "pay" | "hour" | "shop";
+}): Promise<GetNoticesResponse> => {
+  try {
+    const { address, ...rest } = query ?? {}; // address만 분리
+
+    const newQuery = new URLSearchParams();
+
+    // 키값을 하나씩 꺼내 문자열 변환
+    Object.entries(rest).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        newQuery.set(key, String(value));
+      }
+    });
+
+    // 배열로 각 값의 trim 적용, 유효한 값만 append
+    address?.forEach(addr => {
+      const trimmed = addr.trim();
+      if (trimmed) {
+        newQuery.append("address", trimmed);
+      }
+    });
+
+    const response = await instance.get<GetNoticesResponse>(`/notices?${newQuery}`);
+    return response.data;
+  } catch (error) {
+    return handleApiError(error);
+  }
+};
+
+// GET '/shops/{shop_id}/notices' 가게별 공고 조회
+export const getShopNotices = async (
+  shopId: string,
+  query?: { offset?: number; limit?: number },
+): Promise<GetShopNoticesResponse> => {
+  try {
+    const newQuery = new URLSearchParams({
+      offset: String(query?.offset ?? ""),
+      limit: String(query?.limit ?? ""),
+    });
+    const response = await instance.get<GetNoticesResponse>(`/shops/${shopId}/notices?${newQuery}`);
+    return response.data;
+  } catch (error) {
+    return handleApiError(error);
+  }
+};
+
+// POST '/shops/{shop_id}/notices' 공고 등록
+export const postShopNotice = async (shopId: string, body: NoticeBodyRequst): Promise<NoticeShopInfo> => {
+  try {
+    const response = await instance.post<NoticeShopInfo>(`/shops/${shopId}/notices`, body);
+    return response.data;
+  } catch (error) {
+    return handleApiError(error);
+  }
+};
+
+// GET '/shops/{shop_id}/notices/{notice_id}' - 가게의 특정 공고 조회
+export const getShopNotice = async (shopId: string, noticeId: string): Promise<GetShopNoticesResponse> => {
+  try {
+    const response = await instance.get<GetShopNoticesResponse>(`
+            /shops/${shopId}/notices/${noticeId}`);
+    return response.data;
+  } catch (error) {
+    return handleApiError(error);
+  }
+};
+
+// PUT '/shops/{shop_id}/notices/{notice_id}' - 특정 공고 수정
+export const putShopNotice = async (
+  shopId: string,
+  noticeId: string,
+  body: NoticeBodyRequst,
+): Promise<NoticeShopInfo> => {
+  try {
+    const response = await instance.put<NoticeShopInfo>(`/shops/${shopId}/notices/${noticeId}`, body);
+    return response.data;
+  } catch (error) {
+    return handleApiError(error);
+  }
+};

--- a/src/api/shop/ShopApi.ts
+++ b/src/api/shop/ShopApi.ts
@@ -1,10 +1,6 @@
-import instance from "../axios";
-import { AxiosError } from "axios";
+import instance from "@/api/axios";
+import { handleApiError } from "../error/ErrorHandler";
 import { ShopRequest, ShopResponse } from "@/types/shop";
-
-interface ErrorMessage {
-  message: string;
-}
 
 // POST '/shops' - 가게 등록
 export const postShop = async (body: ShopRequest): Promise<ShopResponse> => {
@@ -12,13 +8,7 @@ export const postShop = async (body: ShopRequest): Promise<ShopResponse> => {
     const response = await instance.post<ShopResponse>("/shops", body);
     return response.data;
   } catch (error) {
-    const axiosError = error as AxiosError<ErrorMessage>; //  에러 타입 명시
-
-    if (axiosError.response) {
-      throw new Error(axiosError.response.data.message);
-    } else {
-      throw new Error("서버를 연결할 수 없습니다. 인터넷 연결을 확인해주세요.");
-    }
+    return handleApiError(error);
   }
 };
 
@@ -28,13 +18,7 @@ export const getShop = async (shopId: string): Promise<ShopResponse> => {
     const response = await instance.get<ShopResponse>(`/shops/${shopId}`);
     return response.data;
   } catch (error) {
-    const axiosError = error as AxiosError<ErrorMessage>; //  에러 타입 명시
-
-    if (axiosError.response) {
-      throw new Error(axiosError.response.data.message);
-    } else {
-      throw new Error("서버를 연결할 수 없습니다. 인터넷 연결을 확인해주세요.");
-    }
+    return handleApiError(error);
   }
 };
 
@@ -44,12 +28,6 @@ export const putShop = async (shopId: string, body: ShopRequest): Promise<ShopRe
     const response = await instance.put<ShopResponse>(`/shops/${shopId}`, body);
     return response.data;
   } catch (error) {
-    const axiosError = error as AxiosError<ErrorMessage>; //  에러 타입 명시
-
-    if (axiosError.response) {
-      throw new Error(axiosError.response.data.message);
-    } else {
-      throw new Error("서버를 연결할 수 없습니다. 인터넷 연결을 확인해주세요.");
-    }
+    return handleApiError(error);
   }
 };

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -1,0 +1,73 @@
+import { ShopInfomation } from "./shop";
+import { Application } from "./notification";
+import { LinkInfo } from "./links";
+
+export interface Notice {
+  id: string;
+  hourlyPay: number; //  시급
+  description: string; // 공고 설명
+  startsAt: string; // 근무 시작 시간
+  workhour: number; // 근무 시간
+  closed: boolean; //마감 여부
+}
+
+// shop 포함된 확장형 Notice (리스트, 등록, 수정에 사용)
+export interface NoticeShopItem extends Notice {
+  shop: ShopInfomation;
+}
+
+// application까지 포함된 상세형 Notice (상세 조회 시 사용)
+export interface NoticeDetailItem extends NoticeShopItem {
+  currentUserApplication: null | {
+    item: Application;
+  };
+}
+
+export interface NoticeInfo {
+  item: Notice;
+  links: LinkInfo[];
+}
+
+// POST '/shops/{shop_id}/notices' - 공고 등록 Response
+// PUT '/shops/{shop_id}/notices/{notice_id}' - 특정 공고 수정 Response
+export interface NoticeShopInfo {
+  item: NoticeShopItem;
+  links: LinkInfo[];
+}
+
+// GET '/shops/{shop_id}/notices/{notice_id}' - 가게의 특정 공고 조회 Response
+export interface NoticeDetailInfo {
+  item: NoticeDetailItem;
+  links: LinkInfo[];
+}
+
+// GET '/notices' - 공고 조회 Response
+export interface GetNoticesResponse {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  address: string[];
+  keyword?: string;
+  items: NoticeShopInfo[];
+  links: LinkInfo[];
+}
+
+// GET '/shops/{shop_id}/notices' - 가게별 공고 조회 Response
+export interface GetShopNoticesResponse {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: NoticeInfo[];
+  links: LinkInfo[];
+}
+
+// POST '/shops/{shop_id}/notices' - 공고 등록 Request Body
+// PUT '/shops/{shop_id}/notices/{notice_id}' - 특정 공고 수정 Request Body
+export interface NoticeBodyRequst {
+  hourlyPay: number;
+  startsAt: string;
+  workhour: number;
+  description: string;
+}

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,36 +1,24 @@
-import { Shop } from "./user";
+import { ShopItem } from "./shop";
+import { Notice } from "./notice";
 
 export interface Application {
-  item: {
-    id: string;
-    status: "pending" | "accepted" | "rejected";
-  };
-  href: string;
+  id: string;
+  status: "pending" | "accepted" | "rejected";
 }
 
-export interface Notice {
-  item: {
-    id: string;
-    hourlyPay: number; //  시급
-    description: string; // 공고 설명
-    startsAt: string; // 근무 시작 시간
-    workhour: number; // 근무 시간
-    closed: boolean; //마감 여부
-  };
+export interface ApplicationInfo {
+  item: Application;
   href: string;
 }
 
 export interface NotificationItem {
-  item: {
-    id: string;
-    createdAt: string; // 생성 시간
-    result: "accepted" | "rejected"; // 지원 결과
-    read: boolean; // 읽음 여부
-    application: Application; // 지원서 정보
-    shop: Shop; // 가게 정보
-    notice: Notice; // 공고 정보
-  };
-  links: unknown[];
+  id: string;
+  createdAt: string; // 생성 시간
+  result: "accepted" | "rejected"; // 지원 결과
+  read: boolean; // 읽음 여부
+  application: Application; // 지원서 정보
+  shop: ShopItem; // 가게 정보
+  notice: Notice; // 공고 정보
 }
 
 // 알림 목록 조회


### PR DESCRIPTION
# 개요

Notice 타입 정의을 좀 더 명확하게 바꾸고, 타입 분리를 시켰습니다.
공고 관련 API 파일을 추가하였습니다.

# 추가/변경 사항

## 추가

### `src/types/notice.ts` - Notice 타입 정의 파일
- API 응답 스펙 타입 세분화

### `src/api/notice/NoticeApi.ts` - Notice API 파일
- 공고 관련 API을 사용할 수 있도록 만들었습니다.

### `src/api/error/ErrorHandler.ts` - 공용 에러 핸들러 파일
- 기존 각 API 마다 함수마다 중복됬던 try-catch 에러 처리를 공통 함수로 분리


## 변경

### `src/types/notification.ts` - 알림 타입 정의 파일
-  Notice 타입 분리

### `src/api/shop/ShopApi.ts` - Shop API 파일 
- 에러 처리 ErrorHandler 공통 함수로 적용


## API 연동해보시고 안되시면 문제점을 바로 말씀해주세요 해결해 보겠습니다.