### PR TITLE
[추가] 유저 정보 조회 API 연동

### DIFF
--- a/src/api/alert/AlertsApi.ts
+++ b/src/api/alert/AlertsApi.ts
@@ -1,5 +1,5 @@
-import instance from "../axios";
-import { handleApiError } from "../error/ErrorHandler";
+import instance from "@/api/axios";
+import { handleApiError } from "@/api/error/ErrorHandler";
 import { NotificationListResponse, NotificationReadResponse } from "@/types/notification";
 
 interface ErrorMessage {

--- a/src/api/notice/NoticeApi.ts
+++ b/src/api/notice/NoticeApi.ts
@@ -1,7 +1,6 @@
 import instance from "@/api/axios";
-import { AxiosError } from "axios";
 import { GetNoticesResponse, GetShopNoticesResponse, NoticeBodyRequst, NoticeShopInfo } from "@/types/notice";
-import { handleApiError } from "../error/ErrorHandler";
+import { handleApiError } from "@/api/error/ErrorHandler";
 
 export const getNotices = async (query?: {
   offset?: number;

--- a/src/api/shop/ShopApi.ts
+++ b/src/api/shop/ShopApi.ts
@@ -1,5 +1,5 @@
 import instance from "@/api/axios";
-import { handleApiError } from "../error/ErrorHandler";
+import { handleApiError } from "@/api/error/ErrorHandler";
 import { ShopRequest, ShopResponse } from "@/types/shop";
 
 // POST '/shops' - 가게 등록

--- a/src/api/user/userApi.ts
+++ b/src/api/user/userApi.ts
@@ -1,0 +1,12 @@
+import instance from "@/api/axios";
+import { handleApiError } from "@/api/error/ErrorHandler";
+import { UserDetailResponse } from "@/types/user";
+
+export const getUser = async (userId: string): Promise<UserDetailResponse> => {
+  try {
+    const response = await instance.get<UserDetailResponse>(`/users/${userId}`);
+    return response.data;
+  } catch (error) {
+    return handleApiError(error);
+  }
+};

--- a/src/components/owner/NoticeList.tsx
+++ b/src/components/owner/NoticeList.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/navigation";
 import { PostData } from "@/types/post";
-import PostCard from "../common/post/PostCard";
+import PostCard from "@/components/common/post/PostCard";
 
 interface NoticeListProps {
   notices: PostData[];

--- a/src/components/owner/ShopInfo.tsx
+++ b/src/components/owner/ShopInfo.tsx
@@ -2,16 +2,16 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import Button from "../common/button";
-import { Shop } from "@/types/user";
+import Button from "@/components/common/button";
+import { ShopItem } from "@/types/shop";
 
 interface ShopInfoProps {
-  shop: Shop;
+  shop: ShopItem;
 }
 
 export const ShopInfo = ({ shop }: ShopInfoProps) => {
   return (
-    <section className="w-full max-w-[964px] my-[60px] mx-auto bg-white">
+    <section className="w-full max-w-[964px] my-[60px] bg-white">
       <div className=" w-full">
         <div className="mb-6">
           <h2 className="text-h1">내 가게</h2>
@@ -19,15 +19,15 @@ export const ShopInfo = ({ shop }: ShopInfoProps) => {
         <div className="flex w-full bg-red-10 p-6 gap-[30px] rounded-xl">
           {/* 가게 이미지 */}
           <div className="relative w-[539px] h-[309px]">
-            <Image src={shop.item.imageUrl} alt={shop.item.name} fill className="object-cover rounded-xl" priority />
+            <Image src={shop.imageUrl} alt={shop.name} fill className="object-cover rounded-xl" priority />
           </div>
 
           {/* 가게 정보 */}
           <div className="w-[346px] flex flex-col justify-between gap-3 grow-0">
             {/* 가게 타이틀 */}
             <div>
-              <span className="text-body-1-bold text-primary-10">{shop.item.category}</span>
-              <h2 className="text-h1">{shop.item.name}</h2>
+              <span className="text-body-1-bold text-primary-10">{shop.category}</span>
+              <h2 className="text-h1">{shop.name}</h2>
             </div>
             {/* 주소 */}
             <div className="flex gap-1.5 text-body-1-regular ">
@@ -38,16 +38,16 @@ export const ShopInfo = ({ shop }: ShopInfoProps) => {
                 alt="주소 아이콘"
                 style={{ width: "20px", height: "20px" }}
               />
-              <span className="text-gray-50">{shop.item.address1}</span>
+              <span className="text-gray-50">{shop.address1}</span>
             </div>
             {/* 가게 정보 */}
             <div className="grow text-body-1-regular">
-              <p>{shop.item.description}</p>
+              <p>{shop.description}</p>
             </div>
             {/* 버튼 */}
             <div className="w-full flex gap-2">
               <div className="w-full">
-                <Link href={`/owner/edit-shop/${shop.item.id}`}>
+                <Link href={`/owner/edit-shop/${shop.id}`}>
                   <Button variant="outlined" className=" w-full" size="large">
                     편집하기
                   </Button>

--- a/src/hooks/useUserData.ts
+++ b/src/hooks/useUserData.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getUser } from "@/api/user/userApi";
+import { UserDetailItem } from "@/types/user";
+
+interface UseUserDataReturn {
+  userData: UserDetailItem | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export const useUserData = (userId: string | undefined): UseUserDataReturn => {
+  const [userData, setUserData] = useState<UserDetailItem | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchUserData = async () => {
+    // userId가 없으면 진행 X
+    if (!userId) {
+      setUserData(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await getUser(userId);
+      // 데이터 저장
+      setUserData(response.item);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "사용자 정보를 불러오는데 실패했습니다.";
+      setError(message);
+      setUserData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUserData();
+  }, [userId]);
+
+  return {
+    userData,
+    isLoading,
+    error,
+    refetch: fetchUserData,
+  };
+};

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -1,6 +1,6 @@
-import { ShopInfomation } from "./shop";
-import { Application } from "./notification";
-import { LinkInfo } from "./links";
+import { ShopInfomation } from "@/types/shop";
+import { Application } from "@/types/notification";
+import { LinkInfo } from "@/types/links";
 
 export interface Notice {
   id: string;

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,5 +1,5 @@
-import { ShopItem } from "./shop";
-import { Notice } from "./notice";
+import { ShopItem } from "@/types/shop";
+import { Notice } from "@/types/notice";
 
 export interface Application {
   id: string;

--- a/src/types/shop.ts
+++ b/src/types/shop.ts
@@ -1,6 +1,6 @@
 import { REGION_OPTIONS, CATEGORY_OPTIONS } from "@/constants/options";
-import { User } from "./user";
-import { LinkInfo } from "./links";
+import { User } from "@/types/user";
+import { LinkInfo } from "@/types/links";
 
 export interface ShopItem {
   id: string;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,17 +1,28 @@
-import { ShopInfomation } from "./shop";
+import { LinkInfo } from "@/types/links";
+import { ShopItem } from "@/types/shop";
 
-export type UserType = User["type"] | null;
+export type UserType = "employer" | "employee" | null;
 
 // 유저 정보 (내 정보 조회)
 export interface User {
   id: string;
   email: string; // 로그인 이메일
-  type: "employer" | "employee"; // 사장 | 알바
+  type: UserType; // 사장 | 알바
   name?: string; // 이름
   phone?: string; // 연락처
   address?: string; // 선호 지역
   bio?: string; // 자기 소개
-  shop?: ShopInfomation | null; // 사장 유저
+}
+
+// Shop 정보 포함된 유저 (상세 조회)
+export interface UserDetailItem extends User {
+  shop: { item: ShopItem } | null;
+}
+
+// GET '/users/{userId}' - 유저 정보 조회 Response
+export interface UserDetailResponse {
+  item: UserDetailItem;
+  links: LinkInfo[];
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
# 개요

User 타입 정의을 좀 더 명확하게 바꾸었습니다.
유저 정보 조회 관련 API 파일을 추가하였습니다.

# 추가/변경 사항

## 추가

### `src/hooks/useUserData.ts` - 유저 정보 커스텀 훅 파일
- API 연동 하여 유저 정보를 받아와 유저 타입이 사장일 경우 가게 id를 받아옵니다

## 변경

### `src/types/user.ts` - 유저 타입 파일
- 유저 리스폰스 타입, 리퀘스트 타입 정의, User 타입 리팩토링

### `AlertsApi.ts`, `NoticeApi.ts`, `ShopApi.ts`, `NoticeList.tsx`, `ShopInfo.tsx`, `notice.ts`, `notification.ts`, `shop.ts`
-  경로 변경
