### PR TITLE
[추가]가게 상세정보 페이지 구현

### DIFF
--- a/src/api/notice/NoticeApi.ts
+++ b/src/api/notice/NoticeApi.ts
@@ -70,7 +70,7 @@ export const postShopNotice = async (shopId: string, body: NoticeBodyRequst): Pr
 export const getShopNotice = async (shopId: string, noticeId: string): Promise<GetShopNoticesResponse> => {
   try {
     const response = await instance.get<GetShopNoticesResponse>(`
-            /shops/${shopId}/notices?${noticeId}`);
+            /shops/${shopId}/notices/${noticeId}`);
     return response.data;
   } catch (error) {
     return handleApiError(error);

--- a/src/app/(dashboard)/owner/page.tsx
+++ b/src/app/(dashboard)/owner/page.tsx
@@ -1,7 +1,83 @@
-import React from "react";
+"use client";
 
-function page() {
-  return <div>page</div>;
+import { useAuth } from "@/hooks/useAuth";
+import { useUserData } from "@/hooks/useUserData";
+import { useNoticeData } from "@/hooks/useNoticeData";
+
+import { EmptyShop } from "@/components/owner/EmptyShop";
+import { ShopInfo } from "@/components/owner/ShopInfo";
+import { EmptyNotice } from "@/components/owner/EmptyNotice";
+import { NoticeList } from "@/components/owner/NoticeList";
+
+export default function OwnerPage() {
+  const { user } = useAuth();
+  const { userData, isLoading: isUserLoading, error: userError } = useUserData(user?.id);
+
+  // 가게 정보 가져오기
+  const shop = userData?.shop?.item || null;
+
+  // 공고 목록 가져오기
+  const {
+    notices,
+    isLoading: isNoticesLoading,
+    error: noticesError,
+    hasNext,
+    count,
+    loadMore,
+  } = useNoticeData(shop, { limit: 6 });
+
+  // 가게 로딩
+  if (isUserLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div>로딩 중...</div>
+      </div>
+    );
+  }
+
+  // 가게 에러
+  if (userError) {
+    return (
+      <main className="w-full max-w-[964px] mx-auto px-8 py-[60px]">
+        <div className="text-red-500">에러: {userError}</div>
+      </main>
+    );
+  }
+
+  // 조건 1: 가게가 등록되지 않은 경우
+  if (!shop) {
+    return (
+      <main className="w-full h-screen max-w-[964px] mx-auto px-8">
+        <section className="mt-[60px]">
+          <h1 className="text-h1 mb-6">내 가게</h1>
+          <EmptyShop />
+        </section>
+      </main>
+    );
+  }
+
+  // 조건 2 & 3: 가게는 등록되어 있는 경우
+  return (
+    <main className="w-full flex flex-col items-center">
+      {/* 가게 정보 섹션 */}
+      <ShopInfo shop={shop} />
+
+      {/* 공고 섹션 */}
+      <section className="w-full h-full pt-[60] pb-[120px] bg-gray-5">
+        <div className="max-w-[964px] w-full mx-auto">
+          <h2 className="text-h1 mb-6 ">{count > 0 ? "내가 등록한 공고" : "등록한 공고"}</h2>
+
+          {noticesError ? (
+            <div className="text-red-500 p-4 border border-red-500 rounded">
+              공고 목록을 불러오는데 실패했습니다: {noticesError}
+            </div>
+          ) : notices.length === 0 && !isNoticesLoading ? (
+            <EmptyNotice />
+          ) : (
+            <NoticeList notices={notices} hasNext={hasNext} isLoading={isNoticesLoading} loadMore={loadMore} />
+          )}
+        </div>
+      </section>
+    </main>
+  );
 }
-
-export default page;

--- a/src/components/owner/NoticeList.tsx
+++ b/src/components/owner/NoticeList.tsx
@@ -1,23 +1,48 @@
 import { useRouter } from "next/navigation";
 import { PostData } from "@/types/post";
-import PostCard from "../common/post/PostCard";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+import PostCard from "@/components/common/post/PostCard";
 
 interface NoticeListProps {
   notices: PostData[];
+  hasNext: boolean;
+  isLoading: boolean;
+  loadMore: () => void;
 }
 
-export const NoticeList = ({ notices }: NoticeListProps) => {
+export const NoticeList = ({ notices, hasNext, isLoading, loadMore }: NoticeListProps) => {
   const router = useRouter();
+
+  // 무한 스크롤 Ref
+  const { triggerRef } = useInfiniteScroll({
+    callback: loadMore,
+    hasNext,
+    isLoading: isLoading,
+    rootMargin: "1px",
+  });
 
   const handleNoticeClick = (notice: PostData) => {
     router.push(`/owner/notice/${notice.id}`);
   };
 
   return (
-    <div className="max-w-[964px] w-full mx-auto grid grid-cols-2 md:grid-cols-3 gap-4">
-      {notices.map(notice => (
-        <PostCard key={notice.id} post={notice} onClick={() => handleNoticeClick(notice)} />
-      ))}
+    <div className="w-full">
+      {/* 공고 목록 */}
+      <div className="max-w-[964px] w-full mx-auto grid grid-cols-2 md:grid-cols-3 gap-4">
+        {notices.map(notice => (
+          <PostCard key={notice.id} post={notice} onClick={() => handleNoticeClick(notice)} />
+        ))}
+
+        {/* 무한 스크롤 */}
+        <div ref={triggerRef} />
+
+        {/* 로딩 */}
+        {isLoading && (
+          <div className="text-center py-4">
+            <p className="text-body-2-regular text-gray-40">공고를 불러오는 중...</p>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/hooks/useNoticeData.ts
+++ b/src/hooks/useNoticeData.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { getShopNotices } from "@/api/notice/NoticeApi";
+import { Notice } from "@/types/notice";
+import { PostData } from "@/types/post";
+import { ShopItem } from "@/types/shop";
+import { useCallback, useEffect, useState } from "react";
+
+interface UseNoticeDataReturn {
+  notices: PostData[];
+  isLoading: boolean;
+  error: string | null;
+  hasNext: boolean;
+  count: number;
+  loadMore: () => void;
+  refetch: () => Promise<void>;
+}
+
+interface UseNoticeDataOptions {
+  limit?: number;
+}
+
+export const useNoticeData = (shop: ShopItem | null, options: UseNoticeDataOptions = {}): UseNoticeDataReturn => {
+  const [notices, setNotices] = useState<PostData[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [hasNext, setHasNext] = useState(false);
+  const [count, setCount] = useState(0);
+  const [offset, setOffset] = useState<number>(0);
+
+  const { limit = 6 } = options;
+
+  // ✅ useCallback으로 감싸서 불필요한 재생성 방지
+  const fetchNotices = useCallback(
+    async (currentOffset: number, shouldAppend: boolean = false) => {
+      // shop 없으면 공고 조회 X
+      if (!shop) {
+        setNotices([]);
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await getShopNotices(shop.id, { offset: currentOffset, limit });
+
+        // Notice 추출 - map으로 item 추출
+        const noticeItems: Notice[] = response.items.map(noticeInfo => noticeInfo.item);
+
+        // Notice -> PostData 변환
+        const postDataList: PostData[] = noticeItems.map(notice => ({
+          id: notice.id,
+          shop: {
+            id: shop.id,
+            name: shop.name,
+            address1: shop.address1,
+            imageUrl: shop.imageUrl,
+            originalHourlyPay: shop.originalHourlyPay,
+          },
+          hourlyPay: notice.hourlyPay,
+          startsAt: notice.startsAt,
+          workhour: notice.workhour,
+          closed: notice.closed,
+        }));
+
+        if (shouldAppend) {
+          setNotices(prev => [...prev, ...postDataList]);
+        } else {
+          setNotices(postDataList);
+        }
+
+        // 상태 업데이트
+        setHasNext(response.hasNext);
+        setCount(response.count);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "공고 목록을 불러오는데 실패했습니다.";
+        setError(message);
+
+        if (currentOffset === 0) {
+          setNotices([]);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [shop, limit],
+  );
+
+  const loadMore = useCallback(() => {
+    if (!hasNext || isLoading) return;
+
+    const nextOffset = offset + limit;
+    setOffset(nextOffset);
+    fetchNotices(nextOffset, true);
+  }, [hasNext, isLoading, offset, limit, fetchNotices]);
+
+  useEffect(() => {
+    setOffset(0);
+    fetchNotices(0, false);
+  }, [shop?.id, fetchNotices]);
+
+  const refetch = async () => {
+    setOffset(0);
+    await fetchNotices(0, false);
+  };
+
+  return {
+    notices,
+    isLoading,
+    error,
+    hasNext,
+    count,
+    loadMore,
+    refetch,
+  };
+};


### PR DESCRIPTION
# 개요

가게 사장 페이지를 조건식 렌더링으로 구현하였습니다.
shop API을 연결하여 커스텀 훅을 만들었습니다.

# 추가/변경 사항

## 추가

### `src/app/(dashboard)/owner/page.tsx` - 사장 상세 정보 페이지
- 가게 등록하기, 가게 정보, 공고 등록하기, 공고 목록을 조건식 렌더링으로 구현하였습니다.
- 내가 등록한 공고 목록에 무한 스크롤을 적용시켰습니다.

### `src/hooks/useNoticeData.ts` -  공고 목록 커스텀 훅 파일
- 공고 목록 API 응답

| 가게 등록 전 | 가게 등록 후(공고 등록 전) | 공고 등록 후 |
| --- | --- | --- |
|<img width="3360" height="2220" alt="localhost_3000_owner (2)" src="https://github.com/user-attachments/assets/784d572f-c80c-468f-bedb-093346467557" />|<img width="3360" height="2302" alt="localhost_3000_owner (1)" src="https://github.com/user-attachments/assets/46252340-53f4-4dbb-aeb4-64a86b99fbba" />|<img width="3360" height="3322" alt="localhost_3000_owner" src="https://github.com/user-attachments/assets/957f7bf8-45dd-4cbc-826c-7354bae83208" />|

# 추가로 해야할 것

- 편집하기 구현
- 공고 상세 페이지 구현
- 공고 등록

# 수정해야할 사항
공고 목록을 최근 등록 순으로 바꿔야 겠습니다