### PR TITLE
[추가] 공고 지원 API 연동

### DIFF
--- a/src/api/application/ApplicationApi.ts
+++ b/src/api/application/ApplicationApi.ts
@@ -1,0 +1,76 @@
+import instance from "../axios";
+import {
+  ApplicationNoticeResponse,
+  ApplicationNoticeInfo,
+  ApplicationRequest,
+  ApplicationUserResponse,
+} from "@/types/application";
+import { handleApiError } from "../error/ErrorHandler";
+
+// GET - 가게의 특정 공고의 지원 목록 조회
+export const getNoticeApplications = async (
+  shopId: string,
+  noticeId: string,
+  query?: { offset?: number; limit?: number },
+): Promise<ApplicationNoticeResponse> => {
+  try {
+    const newQuery = new URLSearchParams({
+      offset: String(query?.offset ?? ""),
+      limit: String(query?.limit ?? ""),
+    });
+
+    const response = await instance.get<ApplicationNoticeResponse>(
+      `/shops/${shopId}/notices/${noticeId}/applications?${newQuery}`,
+    );
+
+    return response.data;
+  } catch (err) {
+    return handleApiError(err);
+  }
+};
+
+// POST - 가게의 특정 공고 지원 등록
+export const postNoticeApplications = async (shopId: string, noticeId: string): Promise<ApplicationNoticeInfo> => {
+  try {
+    const response = await instance.post<ApplicationNoticeInfo>(`/shops/${shopId}/notices/${noticeId}/applications`);
+    return response.data;
+  } catch (err) {
+    return handleApiError(err);
+  }
+};
+
+// PUT - 가게의 특정 공고 지원 승인, 거절, 취소
+export const putNoticeApplications = async (
+  shopId: string,
+  noticeId: string,
+  applicationId: string,
+  body: ApplicationRequest,
+): Promise<ApplicationNoticeInfo> => {
+  try {
+    const response = await instance.put<ApplicationNoticeInfo>(
+      `/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
+      body,
+    );
+    return response.data;
+  } catch (err) {
+    return handleApiError(err);
+  }
+};
+
+// GET - 유저의 지원 목록 조회
+export const getUserApplications = async (
+  userId: string,
+  query?: { offset?: number; limit?: number },
+): Promise<ApplicationUserResponse> => {
+  try {
+    const newQuery = new URLSearchParams({
+      offset: String(query?.offset ?? ""),
+      limit: String(query?.limit ?? ""),
+    });
+
+    const response = await instance.get(`/users/${userId}/applications?${newQuery}`);
+    return response.data;
+  } catch (err) {
+    return handleApiError(err);
+  }
+};

--- a/src/api/notice/NoticeApi.ts
+++ b/src/api/notice/NoticeApi.ts
@@ -1,7 +1,14 @@
 import instance from "@/api/axios";
-import { GetNoticesResponse, GetShopNoticesResponse, NoticeBodyRequst, NoticeShopInfo } from "@/types/notice";
+import {
+  GetNoticesResponse,
+  GetShopNoticesResponse,
+  NoticeBodyRequst,
+  NoticeDetailInfo,
+  NoticeShopInfo,
+} from "@/types/notice";
 import { handleApiError } from "@/api/error/ErrorHandler";
 
+// GET / notices 공고 조회
 export const getNotices = async (query?: {
   offset?: number;
   limit?: number;
@@ -66,10 +73,9 @@ export const postShopNotice = async (shopId: string, body: NoticeBodyRequst): Pr
 };
 
 // GET '/shops/{shop_id}/notices/{notice_id}' - 가게의 특정 공고 조회
-export const getShopNotice = async (shopId: string, noticeId: string): Promise<GetShopNoticesResponse> => {
+export const getShopNotice = async (shopId: string, noticeId: string): Promise<NoticeDetailInfo> => {
   try {
-    const response = await instance.get<GetShopNoticesResponse>(`
-            /shops/${shopId}/notices/${noticeId}`);
+    const response = await instance.get<NoticeDetailInfo>(`/shops/${shopId}/notices/${noticeId}`);
     return response.data;
   } catch (error) {
     return handleApiError(error);

--- a/src/hooks/useShopNoticeDetail.ts
+++ b/src/hooks/useShopNoticeDetail.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getShopNotice } from "@/api/notice/NoticeApi";
+import { NoticeDetailItem } from "@/types/notice";
+
+interface useShopNoticeDetailData {
+  noticeDetail: NoticeDetailItem | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export const useShopNoticeDetail = (shopId: string | null, noticeId: string | null): useShopNoticeDetailData => {
+  const [noticeDetail, setNoticeDetail] = useState<NoticeDetailItem | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 공고 상세 정보 함수
+  const fetchNoticeDetail = async () => {
+    if (!shopId || !noticeId) {
+      setNoticeDetail(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await getShopNotice(shopId, noticeId);
+
+      setNoticeDetail(response.item);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "공고 정보를 불러오는데 실패했습니다.";
+      setError(message);
+      setNoticeDetail(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchNoticeDetail();
+  }, [shopId, noticeId]);
+
+  return {
+    noticeDetail,
+    isLoading,
+    error,
+    refetch: fetchNoticeDetail,
+  };
+};

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -1,0 +1,61 @@
+import { LinkInfo } from "@/types/links";
+import { NoticeInfo } from "@/types/notice";
+import { ShopInfomation } from "@/types/shop";
+import { User } from "@/types/user";
+
+export type ApplicationStatus = "pending" | "accepted" | "rejected" | "canceled";
+
+export interface Application {
+  id: string;
+  status: "pending" | "accepted" | "rejected";
+  createdAt: string;
+}
+
+export interface ApplicationUserItem extends Application {
+  shop: ShopInfomation;
+  notice: NoticeInfo;
+}
+
+export interface ApplicationNoticeItem extends Application {
+  user: {
+    item: User;
+    href: string;
+  };
+}
+
+export interface ApplicationUserInfo {
+  item: ApplicationUserItem;
+  links: LinkInfo[];
+}
+
+// POST - 가게의 특정 공고 지원 등록 Response
+// PUT - 가게의 특정 공고 지원 승인, 거절, 취소 Response
+export interface ApplicationNoticeInfo {
+  item: ApplicationNoticeItem;
+  links: LinkInfo[];
+}
+
+// GET - 유저의 지원 목록 조회 Response
+export interface ApplicationUserResponse {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: ApplicationUserInfo[];
+  links: LinkInfo[];
+}
+
+// GET - 가게의 특정 공고의 지원 목록 조회 Response
+export interface ApplicationNoticeResponse {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: ApplicationNoticeInfo[];
+  links: LinkInfo[];
+}
+
+// PUT - 가게의 특정 공고 지원 승인, 거절, 취소 Request
+export interface ApplicationRequest {
+  status: Exclude<ApplicationStatus, "pending">; // pending 제외
+}

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -1,5 +1,5 @@
 import { ShopInfomation } from "@/types/shop";
-import { Application } from "@/types/notification";
+import { Application } from "@/types/application";
 import { LinkInfo } from "@/types/links";
 
 export interface Notice {

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,15 +1,6 @@
 import { ShopItem } from "@/types/shop";
 import { Notice } from "@/types/notice";
-
-export interface Application {
-  id: string;
-  status: "pending" | "accepted" | "rejected";
-}
-
-export interface ApplicationInfo {
-  item: Application;
-  href: string;
-}
+import { Application } from "@/types/application";
 
 export interface NotificationItem {
   id: string;


### PR DESCRIPTION
# 개요

공고 상세 페이지에 Table에 연동 시킬 공고 지원 API 로직 파일을 추가하였습니다.

# 추가/변경 사항

## 추가

### `src/api/application/ApplicationApi.ts` - 공고 지원 관련 전체 API 로직 파일 생성

### `src/types/application.ts` -  공고 지원 타입 정의 파일

## 변경

### `/types/notice.ts`, `/types/notification.ts` - 타입 정의 파일 경로 변경


# 추가로 해야할 것

- 공고 상세 페이지 구현
- 페이지 먼저 구현 후 반응형을 구현
- 편집하기 구현
- 알림 API 연동