### PR TITLE
[추가] 사장 공고 상세 페이지 구현

### DIFF
--- a/src/app/(dashboard)/owner/notice/[shopId]/[noticeId]/page.tsx
+++ b/src/app/(dashboard)/owner/notice/[shopId]/[noticeId]/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { NoticeInfo } from "@/components/owner/notice/NoticeInfo";
+import { ApplicationList } from "@/components/owner/notice/ApplicationList";
+import { useShopNoticeDetail } from "@/hooks/useShopNoticeDetail";
+
+export default function NoticeDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+
+  const shopId = typeof params.shopId === "string" ? params.shopId : null;
+  const noticeId = typeof params.noticeId === "string" ? params.noticeId : null;
+
+  const { noticeDetail, isLoading, error } = useShopNoticeDetail(shopId, noticeId);
+
+  // 로딩 중
+  if (isLoading) {
+    return (
+      <main className="w-full min-h-screen bg-gray-5 flex items-center justify-center">
+        <div className="text-body-1-regular text-gray-40">로딩 중...</div>
+      </main>
+    );
+  }
+
+  // 에러 발생
+  if (error || !noticeDetail) {
+    return (
+      <main className="w-full min-h-screen bg-gray-5 flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-body-1-regular text-red-40 mb-4">{error || "공고를 찾을 수 없습니다."}</p>
+          <button
+            onClick={() => router.back()}
+            className="px-4 py-2 bg-primary-20 text-white rounded hover:bg-primary-30"
+          >
+            돌아가기
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="w-full h-full bg-gray-5 flex flex-col items-center">
+      {/* 공고 상세 정보 */}
+      <section className="max-w-[964px] w-full py-[60px]">
+        <div className="mb-6">
+          <span className="text-primary-20 text-body-1-bold mb-2 block">{noticeDetail.shop.item.category}</span>
+          <h1 className="text-h1">{noticeDetail.shop.item.name}</h1>
+        </div>
+        <NoticeInfo noticeDetail={noticeDetail} userRole="employer" />
+      </section>
+      {/* 신청자 목록 */}
+      <section className="max-w-[964px] w-full py-[60px]">
+        <h2 className="text-h1 mb-8">신청자 목록</h2>
+        {shopId && noticeId ? (
+          <ApplicationList shopId={shopId} noticeId={noticeId} />
+        ) : (
+          <div className="text-body-1-regular text-gray-40">유효한 공고 정보가 없습니다.</div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/components/owner/NoticeList.tsx
+++ b/src/components/owner/NoticeList.tsx
@@ -22,7 +22,7 @@ export const NoticeList = ({ notices, hasNext, isLoading, loadMore }: NoticeList
   });
 
   const handleNoticeClick = (notice: PostData) => {
-    router.push(`/owner/notice/${notice.id}`);
+    router.push(`/owner/notice/${notice.shop.id}/${notice.id}`);
   };
 
   return (

--- a/src/components/owner/notice/ApplicationList.tsx
+++ b/src/components/owner/notice/ApplicationList.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useApplications } from "@/hooks/useApplications";
+import { ApplicationNoticeItem } from "@/types/application";
+import { ApplicantData } from "@/types/TablePropsTypes";
+import CommonTable from "@/components/common/table/CommonTableBoss";
+
+interface ApplicationListProps {
+  shopId: string;
+  noticeId: string;
+}
+
+const convertToApplicantData = (application: ApplicationNoticeItem): ApplicantData => {
+  return {
+    id: application.id,
+    name: application.user.item.name ?? "이름 없음",
+    introduction: application.user.item.bio ?? "",
+    phoneNumber: application.user.item.phone ?? "전화번호 없음",
+    status: application.status === "accepted" ? "approved" : application.status,
+  };
+};
+
+export const ApplicationList = ({ shopId, noticeId }: ApplicationListProps) => {
+  const { applications, isLoading, error, approveApplication, rejectApplication } = useApplications(shopId, noticeId);
+
+  /**
+   * 신청 승인 핸들러
+   * @param applicationId - 신청 ID
+   */
+  const handleApprove = async (applicationId: string) => {
+    try {
+      await approveApplication(applicationId);
+      alert("신청 승인 완료");
+    } catch (err) {
+      alert("승인 처리 실패");
+    }
+  };
+
+  const handleReject = async (applicationId: string) => {
+    try {
+      await rejectApplication(applicationId);
+      alert("신청 거절 완료");
+    } catch (err) {
+      alert("거절 처리 실패");
+    }
+  };
+
+  // 로딩
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-12 text-center">
+        <p className="text-body-1-regular text-gray-40">신청자 목록을 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  // 신청자가 없을 때
+  if (applications.length === 0) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-12 text-center">
+        <p className="text-body-1-regular text-gray-40">아직 신청자가 없습니다.</p>
+      </div>
+    );
+  }
+
+  // 에러 발생
+  if (error) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-12 text-center">
+        <p className="text-body-1-regular text-red-40">{error}</p>
+      </div>
+    );
+  }
+
+  // ApplicationNoticeItem[] → ApplicantData[] 변환
+  const applicantData: ApplicantData[] = applications.map(convertToApplicantData);
+
+  return <CommonTable title="" data={applicantData} onApprove={handleApprove} onReject={handleReject} />;
+};

--- a/src/components/owner/notice/NoticeInfo.tsx
+++ b/src/components/owner/notice/NoticeInfo.tsx
@@ -1,0 +1,115 @@
+import Image from "next/image";
+import Link from "next/link";
+import Button from "@/components/common/button";
+import { formatDate, formatTime } from "@/utils/date";
+import { NoticeDetailItem } from "@/types/notice";
+import { UserType } from "@/types/user";
+
+interface NoticeInfoProps {
+  noticeDetail: NoticeDetailItem;
+  userRole?: UserType;
+  onClick?: () => void;
+}
+
+export const NoticeInfo = ({ noticeDetail, userRole = "employer", onClick }: NoticeInfoProps) => {
+  const { shop, hourlyPay, startsAt, workhour, description, closed } = noticeDetail;
+
+  // 숫자를 통화 형식으로 포멧팅
+  const formatCurrency = (amoubt: number): string => {
+    return new Intl.NumberFormat("ko-KR").format(amoubt);
+  };
+
+  // 날짜 포맷팅
+  const formatDateTime = (startTime: string, workHours: number): string => {
+    const start = new Date(startTime);
+    const end = new Date(start.getTime() + workHours * 60 * 60 * 1000);
+
+    const dateStr = formatDate(start).replace(/\. /g, "-").replace(".", ""); // YYYY-MM-DD
+    const startTimeStr = formatTime(start);
+    const endTimeStr = formatTime(end);
+
+    return `${dateStr} ${startTimeStr}~${endTimeStr} (${workHours}시간)`;
+  };
+
+  const calculateIncreaseRate = (): number => {
+    if (!shop.item.originalHourlyPay || shop.item.originalHourlyPay === 0) return 0;
+    return Math.round(((hourlyPay - shop.item.originalHourlyPay) / shop.item.originalHourlyPay) * 100);
+  };
+  const increaseRate = calculateIncreaseRate();
+
+  return (
+    <div className="w-full">
+      <div className=" border border-gray-20 rounded-xl">
+        <div className="flex w-full bg-white p-6 gap-[30px] rounded-xl">
+          {/* 가게 이미지 */}
+          <div className="relative w-[539px] h-[309px]">
+            <Image src={shop.item.imageUrl} alt={shop.item.name} fill className="object-cover rounded-xl" priority />
+          </div>
+
+          {/* 공고 정보 */}
+          <div className="w-[346px] pt-4 flex flex-col justify-between gap-3 grow-0">
+            {/* 공고 시급 */}
+            <div>
+              <span className="text-body-1-bold text-primary-20">시급</span>
+              <div className="flex items-center gap-3">
+                <span className="text-h1">{formatCurrency(hourlyPay)}원</span>
+                {increaseRate > 0 && (
+                  <span className="px-4 py-3  bg-primary-20 text-white text-body-2-bold rounded-full">
+                    기존 시급보다 {increaseRate}% ↑
+                  </span>
+                )}
+              </div>
+            </div>
+            {/* 근무 닐짜 / 시간 */}
+            <div className="flex gap-1.5 text-body-1-regular items-center">
+              <Image
+                src="/clock.svg"
+                width={20}
+                height={20}
+                alt="시간 아이콘"
+                style={{ width: "20px", height: "20px" }}
+              />
+              <span className="text-gray-50 text-body-1-regular">{formatDateTime(startsAt, workhour)}</span>
+            </div>
+            {/* 주소 */}
+            <div className="text-body-1-regular">
+              <div className=" flex gap-1 items-center">
+                <Image
+                  src="/Location.svg"
+                  width={20}
+                  height={20}
+                  alt="시간 아이콘"
+                  style={{ width: "20px", height: "20px" }}
+                />
+                <span className="text-gray-50 text-body-1-regular">
+                  {shop.item.address1} {shop.item.address2}
+                </span>
+              </div>
+            </div>
+            {/* 가게 설명 */}
+            <div className="mb-4 grow">
+              <p className="text-body-1-regular line-clamp-3">{shop.item.description}</p>
+            </div>
+
+            {/* 버튼 */}
+            <div className="w-full flex gap-2">
+              <div className="w-full">
+                <Link href={`/owner/edit-shop/${shop.item.id}`}>
+                  <Button variant="outlined" className=" w-full" size="large">
+                    편집하기
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 공고 설명 */}
+      <div className="w-full bg-gray-10 mt-6 p-8 rounded-xl">
+        <span className="text-body-1-bold text-black mb-3">공고 설명</span>
+        <p className="text-body-1-regular line-clamp-3">{shop.item.description}</p>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/useApplications.ts
+++ b/src/hooks/useApplications.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ApplicationNoticeItem } from "@/types/application";
+import { getNoticeApplications, putNoticeApplications } from "@/api/application/ApplicationApi";
+
+interface UseApplicationsData {
+  applications: ApplicationNoticeItem[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+  approveApplication: (applicationId: string) => Promise<void>;
+  rejectApplication: (applicationId: string) => Promise<void>;
+}
+
+export const useApplications = (shopId: string | null, noticeId: string | null): UseApplicationsData => {
+  const [applications, setApplications] = useState<ApplicationNoticeItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 신청자 목록 패칭
+  const fetchApplications = useCallback(async () => {
+    if (!shopId || !noticeId) {
+      setApplications([]);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await getNoticeApplications(shopId, noticeId);
+
+      const applicationItems = response.items.map(info => info.item);
+      setApplications(applicationItems);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "신청자 목록을 불러오는데 실패했습니다.";
+      setError(message);
+      setApplications([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [shopId, noticeId]);
+
+  // 신청 승인
+  const approveApplication = async (applicationId: string) => {
+    if (!shopId || !noticeId) return;
+
+    try {
+      await putNoticeApplications(shopId, noticeId, applicationId, {
+        status: "accepted",
+      });
+
+      setApplications(prev =>
+        prev.map(app => (app.id === applicationId ? { ...app, status: "accepted" as const } : app)),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "승인 처리에 실패했습니다.";
+      setError(message);
+      throw err;
+    }
+  };
+
+  // 신청 거절
+
+  const rejectApplication = async (applicationId: string) => {
+    if (!shopId || !noticeId) return;
+
+    try {
+      await putNoticeApplications(shopId, noticeId, applicationId, {
+        status: "rejected",
+      });
+
+      setApplications(prev =>
+        prev.map(app => (app.id === applicationId ? { ...app, status: "rejected" as const } : app)),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "거절 처리에 실패했습니다.";
+      setError(message);
+      throw err;
+    }
+  };
+
+  useEffect(() => {
+    fetchApplications();
+  }, [fetchApplications]);
+
+  return {
+    applications,
+    isLoading,
+    error,
+    refetch: fetchApplications,
+    approveApplication,
+    rejectApplication,
+  };
+};


### PR DESCRIPTION
# 개요

사장 유저가 자신의 공고를 상세 조회하고 신청자를 관리할 수 있는 페이지를 구현했습니다.

# 추가/변경 사항

## 추가

```
hooks/
├── useShopNoticeDetail.ts    # 공고 상세 조회 훅
└── useApplications.ts         # 신청자 목록 관리 훅

components/owner/notice/
├── NoticeInfo.tsx             # 공고 정보 컴포넌트
└── ApplicationList.tsx        # 신청자 목록 컴포넌트

app/owner/notice/[shopId]/[noticeId]/
└── page.tsx                   # 공고 상세 페이지
```


## 변경

### `src/components/owner/NoticeList.tsx` - 라우팅 경로 변경

| 공고 상세 페이지 |
| --- |
|<img width="3360" height="2838" alt="localhost_3000_owner_notice_80180007-8b8b-4061-b8c2-52948ed6f73f_3b8ed8a1-64cb-4dcd-a66e-bcb2fab3ffd4" src="https://github.com/user-attachments/assets/981f246d-0d97-4ee8-aee2-e65fc1368aa5" />|

# 추가 작업분(순서)

1. 테이블과 페이지네이션이 따로 구분지어진걸 모르고 제작 했습니다. 바로 구현하겠습니다
2.  편집모드 구현
3. 알림 API 연동
4. 페이지 먼저 구현 후 반응형을 구현
5. 모달(토스트) 연동