### PR TITLE
[찬민] 로그인,회원가입 페이지 로고 클릭시 공고리스트로 이동

### DIFF
--- a/src/components/login/LoginUi.tsx
+++ b/src/components/login/LoginUi.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
+import Link from "next/link";
 import Input from "@/components/common/input/Input";
 import Button from "@/components/common/button";
 import Modal from "@/components/common/modal/CommonModal";
@@ -111,7 +112,9 @@ export default function LoginUi() {
     <div className="flex flex-col items-center justify-center min-h-screen bg-white px-4">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
-          <Image src="/logo.svg" alt="THE JULGE 로고" width={248} height={45} className="mx-auto" />
+          <Link href="/jobs">
+            <Image src="/logo.svg" alt="THE JULGE 로고" width={248} height={45} className="mx-auto cursor-pointer" />
+          </Link>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">

--- a/src/components/signup/SignupUi.tsx
+++ b/src/components/signup/SignupUi.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import Input from "@/components/common/input/Input";
 import Button from "@/components/common/button";
 import Modal from "@/components/common/modal/CommonModal";
@@ -28,7 +29,9 @@ export default function SignupUi() {
     <div className="flex flex-col items-center justify-center min-h-screen bg-white px-4">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
-          <Image src="/logo.svg" alt="THE JULGE 로고" width={248} height={45} className="mx-auto" />
+          <Link href="/jobs">
+            <Image src="/logo.svg" alt="THE JULGE 로고" width={248} height={45} className="mx-auto cursor-pointer" />
+          </Link>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6" noValidate>

--- a/src/contexts/AuthLoginApi.tsx
+++ b/src/contexts/AuthLoginApi.tsx
@@ -10,7 +10,7 @@ type AuthStateListener = (user: User | null) => void;
 export class AuthLoginApi {
   private static listeners: AuthStateListener[] = [];
   private static currentUser: User | null = null;
-  private static readonly TOKEN_EXPIRY_MINUTES = 1; // 분 단위로 토큰 유효시간 설정가능
+  private static readonly TOKEN_EXPIRY_MINUTES = 5; // 분 단위로 토큰 유효시간 설정가능
 
   // 상태 변경 리스너 등록/해제
   static subscribe(listener: AuthStateListener): () => void {


### PR DESCRIPTION

<img width="1142" height="1270" alt="image" src="https://github.com/user-attachments/assets/317f52e2-3793-4142-9fae-024f0c7069a4" />



로그인, 회원가입 페이지에 로고를 클릭하면 로그인이 되어있지 않은 상태에서도 공고페이지로 이동하는
링크를 추가하였습니다.

링크 이동은 링크 컴포넌트를 사용해서 마우스 호버 상태에서 브라우저 좌측 하단에 어디로 라우팅되는지 확인할 수 있습니다