### PR TITLE
[찬민] 모달 사용자 경고 코드리뷰 피드백 반영(useRouter 사용, 리액트 dom 직접조작 변경)

### DIFF
--- a/src/api/application/ApplicationApi.ts
+++ b/src/api/application/ApplicationApi.ts
@@ -1,0 +1,76 @@
+import instance from "../axios";
+import {
+  ApplicationNoticeResponse,
+  ApplicationNoticeInfo,
+  ApplicationRequest,
+  ApplicationUserResponse,
+} from "@/types/application";
+import { handleApiError } from "../error/ErrorHandler";
+
+// GET - 가게의 특정 공고의 지원 목록 조회
+export const getNoticeApplications = async (
+  shopId: string,
+  noticeId: string,
+  query?: { offset?: number; limit?: number },
+): Promise<ApplicationNoticeResponse> => {
+  try {
+    const newQuery = new URLSearchParams({
+      offset: String(query?.offset ?? ""),
+      limit: String(query?.limit ?? ""),
+    });
+
+    const response = await instance.get<ApplicationNoticeResponse>(
+      `/shops/${shopId}/notices/${noticeId}/applications?${newQuery}`,
+    );
+
+    return response.data;
+  } catch (err) {
+    return handleApiError(err);
+  }
+};
+
+// POST - 가게의 특정 공고 지원 등록
+export const postNoticeApplications = async (shopId: string, noticeId: string): Promise<ApplicationNoticeInfo> => {
+  try {
+    const response = await instance.post<ApplicationNoticeInfo>(`/shops/${shopId}/notices/${noticeId}/applications`);
+    return response.data;
+  } catch (err) {
+    return handleApiError(err);
+  }
+};
+
+// PUT - 가게의 특정 공고 지원 승인, 거절, 취소
+export const putNoticeApplications = async (
+  shopId: string,
+  noticeId: string,
+  applicationId: string,
+  body: ApplicationRequest,
+): Promise<ApplicationNoticeInfo> => {
+  try {
+    const response = await instance.put<ApplicationNoticeInfo>(
+      `/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
+      body,
+    );
+    return response.data;
+  } catch (err) {
+    return handleApiError(err);
+  }
+};
+
+// GET - 유저의 지원 목록 조회
+export const getUserApplications = async (
+  userId: string,
+  query?: { offset?: number; limit?: number },
+): Promise<ApplicationUserResponse> => {
+  try {
+    const newQuery = new URLSearchParams({
+      offset: String(query?.offset ?? ""),
+      limit: String(query?.limit ?? ""),
+    });
+
+    const response = await instance.get(`/users/${userId}/applications?${newQuery}`);
+    return response.data;
+  } catch (err) {
+    return handleApiError(err);
+  }
+};

--- a/src/api/notice/NoticeApi.ts
+++ b/src/api/notice/NoticeApi.ts
@@ -1,7 +1,14 @@
 import instance from "@/api/axios";
-import { GetNoticesResponse, GetShopNoticesResponse, NoticeBodyRequst, NoticeShopInfo } from "@/types/notice";
+import {
+  GetNoticesResponse,
+  GetShopNoticesResponse,
+  NoticeBodyRequst,
+  NoticeDetailInfo,
+  NoticeShopInfo,
+} from "@/types/notice";
 import { handleApiError } from "@/api/error/ErrorHandler";
 
+// GET / notices 공고 조회
 export const getNotices = async (query?: {
   offset?: number;
   limit?: number;
@@ -66,10 +73,9 @@ export const postShopNotice = async (shopId: string, body: NoticeBodyRequst): Pr
 };
 
 // GET '/shops/{shop_id}/notices/{notice_id}' - 가게의 특정 공고 조회
-export const getShopNotice = async (shopId: string, noticeId: string): Promise<GetShopNoticesResponse> => {
+export const getShopNotice = async (shopId: string, noticeId: string): Promise<NoticeDetailInfo> => {
   try {
-    const response = await instance.get<GetShopNoticesResponse>(`
-            /shops/${shopId}/notices/${noticeId}`);
+    const response = await instance.get<NoticeDetailInfo>(`/shops/${shopId}/notices/${noticeId}`);
     return response.data;
   } catch (error) {
     return handleApiError(error);

--- a/src/api/profile/profileApi.ts
+++ b/src/api/profile/profileApi.ts
@@ -1,0 +1,75 @@
+// src/api/profile/profileApi.ts
+import secureAxios from "@/api/secureAxios";
+import { handleApiError } from "@/api/error/ErrorHandler";
+
+// ✅ 프로필 조회
+export const getProfile = async (userId: string) => {
+  try {
+    const res = await secureAxios.get(`/users/${userId}`);
+    return res.data.item || res.data;
+  } catch (error) {
+    console.error("프로필 조회 실패:", error);
+    throw handleApiError(error);
+  }
+};
+
+// ✅ 프로필 등록
+export const saveProfile = async (
+  userId: string,
+  data: { name: string; phone: string; region: string; intro: string },
+) => {
+  try {
+    const cleanPhone = (data.phone || "").replace(/[^0-9]/g, "");
+    const payload = {
+      name: data.name ?? "",
+      phone: cleanPhone,
+      address: data.region ?? "",
+      bio: data.intro ?? "",
+    };
+
+    console.log("프로필 등록 요청:", payload);
+
+    const res = await secureAxios.put(`/users/${userId}`, payload);
+    return res.data;
+  } catch (error) {
+    console.error("프로필 등록 실패:", error);
+    throw handleApiError(error);
+  }
+};
+
+// ✅ 프로필 수정
+export const updateProfile = async (
+  userId: string,
+  data: { name: string; phone: string; region: string; intro: string },
+) => {
+  try {
+    const cleanPhone = (data.phone || "").replace(/[^0-9]/g, "");
+    const payload = {
+      name: data.name ?? "",
+      phone: cleanPhone,
+      address: data.region ?? "",
+      bio: data.intro ?? "",
+    };
+
+    console.log("프로필 수정 요청:", payload);
+
+    const res = await secureAxios.put(`/users/${userId}`, payload);
+    return res.data;
+  } catch (error) {
+    console.error("프로필 수정 실패:", error);
+    throw handleApiError(error);
+  }
+};
+
+// ✅ 신청 내역 조회
+export const getApplications = async (userId: string) => {
+  try {
+    const res = await secureAxios.get(`/users/${userId}/applications`);
+    if (Array.isArray(res.data)) return res.data;
+    if (Array.isArray(res.data.applications)) return res.data.applications;
+    return [];
+  } catch (error) {
+    console.error("❌ 신청 내역 조회 실패:", error);
+    return [];
+  }
+};

--- a/src/api/secureAxios.ts
+++ b/src/api/secureAxios.ts
@@ -1,0 +1,22 @@
+import axios, { AxiosInstance } from "axios";
+
+/**
+ * ✅ 인증이 필요한 요청 전용 Axios 인스턴스
+ * 기존 axios.ts는 /users 요청을 인증 제외시켰기 때문에
+ * 이 파일에서는 모든 요청에 accessToken을 포함합니다.
+ */
+
+const secureAxios: AxiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "https://bootcamp-api.codeit.kr/api/18-1/the-julge",
+  headers: { "Content-Type": "application/json" },
+});
+
+secureAxios.interceptors.request.use(config => {
+  const token = localStorage.getItem("accessToken");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default secureAxios;

--- a/src/app/(dashboard)/owner/notice/[shopId]/[noticeId]/page.tsx
+++ b/src/app/(dashboard)/owner/notice/[shopId]/[noticeId]/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { NoticeInfo } from "@/components/owner/notice/NoticeInfo";
+import { ApplicationList } from "@/components/owner/notice/ApplicationList";
+import { useShopNoticeDetail } from "@/hooks/useShopNoticeDetail";
+
+export default function NoticeDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+
+  const shopId = typeof params.shopId === "string" ? params.shopId : null;
+  const noticeId = typeof params.noticeId === "string" ? params.noticeId : null;
+
+  const { noticeDetail, isLoading, error } = useShopNoticeDetail(shopId, noticeId);
+
+  // 로딩 중
+  if (isLoading) {
+    return (
+      <main className="w-full min-h-screen bg-gray-5 flex items-center justify-center">
+        <div className="text-body-1-regular text-gray-40">로딩 중...</div>
+      </main>
+    );
+  }
+
+  // 에러 발생
+  if (error || !noticeDetail) {
+    return (
+      <main className="w-full min-h-screen bg-gray-5 flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-body-1-regular text-red-40 mb-4">{error || "공고를 찾을 수 없습니다."}</p>
+          <button
+            onClick={() => router.back()}
+            className="px-4 py-2 bg-primary-20 text-white rounded hover:bg-primary-30"
+          >
+            돌아가기
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="w-full h-full bg-gray-5 flex flex-col items-center">
+      {/* 공고 상세 정보 */}
+      <section className="max-w-[964px] w-full py-[60px]">
+        <div className="mb-6">
+          <span className="text-primary-20 text-body-1-bold mb-2 block">{noticeDetail.shop.item.category}</span>
+          <h1 className="text-h1">{noticeDetail.shop.item.name}</h1>
+        </div>
+        <NoticeInfo noticeDetail={noticeDetail} userRole="employer" />
+      </section>
+      {/* 신청자 목록 */}
+      <section className="max-w-[964px] w-full py-[60px]">
+        <h2 className="text-h1 mb-8">신청자 목록</h2>
+        {shopId && noticeId ? (
+          <ApplicationList shopId={shopId} noticeId={noticeId} />
+        ) : (
+          <div className="text-body-1-regular text-gray-40">유효한 공고 정보가 없습니다.</div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/app/profile/detail/page.tsx
+++ b/src/app/profile/detail/page.tsx
@@ -1,60 +1,108 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import instance from "@/api/axios";
-
-interface ProfileData {
-  name: string;
-  phone: string;
-  region: string;
-  intro: string;
-}
+import { useRouter } from "next/navigation";
+import Button from "@/components/common/button";
+import { AuthLoginApi } from "@/contexts/AuthLoginApi";
+import { getProfile, getApplications } from "@/api/profile/profileApi";
 
 export default function ProfileDetailPage() {
-  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const router = useRouter();
+  const [profile, setProfile] = useState<any>(null);
+  const [applications, setApplications] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
-  const userId = localStorage.getItem("userId");
 
   useEffect(() => {
-    const fetchProfile = async () => {
-      if (!userId) {
-        alert("로그인 정보가 없습니다. 다시 로그인해주세요.");
-        return;
-      }
+    const user = AuthLoginApi.getCurrentUser() ?? AuthLoginApi.restoreUserFromStorage();
+    if (!user?.id) {
+      alert("로그인이 필요합니다.");
+      router.push("/login");
+      return;
+    }
 
-      try {
-        const res = await instance.get(`/users/${userId}`);
-        setProfile(res.data);
-      } catch (err) {
-        console.error("프로필 불러오기 실패:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
+    fetchData(user.id);
+  }, [router]);
 
-    fetchProfile();
-  }, [userId]);
+  const fetchData = async (id: string) => {
+    try {
+      const [profileRes, appRes] = await Promise.all([getProfile(id), getApplications(id)]);
+      setProfile(profileRes);
+      setApplications(appRes.applications || []);
+    } catch (error) {
+      console.error("❌ 데이터 불러오기 실패:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   if (loading) return <p className="text-center mt-10">불러오는 중...</p>;
-  if (!profile) return <p className="text-center mt-10">프로필 정보를 불러오지 못했습니다.</p>;
 
   return (
-    <main
-      className="
-        w-full max-w-[957px] mx-auto
-        px-5 tablet:px-6
-        pt-[40px] pb-[120px]
-        min-h-screen
-      "
-    >
-      <h1 className="text-h2 font-bold mb-[40px]">내 프로필</h1>
+    <main className="min-h-screen max-w-[957px] mx-auto px-5 py-[60px]">
+      <h1 className="text-h2 font-bold mb-[24px] text-black">내 프로필</h1>
 
-      <div className="border border-gray-10 rounded-[12px] bg-gray-0 p-[32px]">
-        <p className="text-body-1-semibold mb-2">이름: {profile.name}</p>
-        <p className="text-body-1-semibold mb-2">연락처: {profile.phone}</p>
-        <p className="text-body-1-semibold mb-2">선호 지역: {profile.region}</p>
-        <p className="text-body-1-regular">소개: {profile.intro}</p>
-      </div>
+      {/* ✅ 프로필 카드 */}
+      <section className="border border-gray-20 rounded-[8px] bg-[#FFF5F5] py-[32px] px-[24px] mb-[80px] relative shadow-sm">
+        <div className="flex flex-col gap-[8px] text-gray-900">
+          <div className="flex items-center justify-between mb-[8px]">
+            <p className="text-h3 font-semibold text-red-500">이름</p>
+            <button
+              onClick={() => router.push("/profile/edit")}
+              className="text-sm border border-gray-30 text-gray-80 px-[12px] py-[4px] rounded-[4px] hover:bg-gray-100"
+            >
+              편집하기
+            </button>
+          </div>
+
+          <p className="text-body-1-semibold text-black">{profile.name}</p>
+          <p className="text-body-2-regular text-gray-70">📞 {profile.phone}</p>
+          <p className="text-body-2-regular text-gray-70">📍 {profile.address}</p>
+          <p className="text-body-1-regular text-gray-80 mt-[8px] leading-relaxed">{profile.bio}</p>
+        </div>
+      </section>
+
+      {/* ✅ 신청 내역 */}
+      <section>
+        <h2 className="text-h3 font-bold mb-[24px] text-black">신청 내역</h2>
+
+        {applications.length > 0 ? (
+          <div className="border border-gray-20 rounded-[8px] bg-white shadow-sm divide-y divide-gray-10">
+            {applications.map(app => (
+              <div key={app.id} className="flex justify-between items-center p-[20px] hover:bg-gray-50 transition">
+                <div>
+                  <p className="text-body-1-semibold text-black">{app.noticeTitle}</p>
+                  <p className="text-body-2-regular text-gray-60">
+                    {app.shopName} • {new Date(app.createdAt).toLocaleDateString("ko-KR")}
+                  </p>
+                </div>
+                <span
+                  className={`px-3 py-1 rounded-full text-sm ${
+                    app.status === "pending"
+                      ? "bg-yellow-100 text-yellow-800"
+                      : app.status === "accepted"
+                      ? "bg-green-100 text-green-800"
+                      : "bg-red-100 text-red-700"
+                  }`}
+                >
+                  {app.status === "pending" ? "대기중" : app.status === "accepted" ? "승인됨" : "거절됨"}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="border border-gray-20 rounded-[8px] bg-gray-0 py-[56px] px-[24px] text-center shadow">
+            <p className="text-body-1-regular text-gray-50 mb-[28px]">아직 신청 내역이 없어요.</p>
+            <Button
+              variant="primary"
+              size="large"
+              className="w-[240px] h-[47px] mx-auto"
+              onClick={() => router.push("/jobs")}
+            >
+              공고 보러가기
+            </Button>
+          </div>
+        )}
+      </section>
     </main>
   );
 }

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -1,83 +1,80 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import Button from "@/components/common/button";
 import Modal from "@/components/common/modal/CommonModal";
-import instance from "@/api/axios";
 import { REGION_OPTIONS } from "@/constants/options";
-
-interface ProfileForm {
-  name: string;
-  phone: string;
-  region: string;
-  intro: string;
-}
+import { AuthLoginApi } from "@/contexts/AuthLoginApi";
+import { getProfile, updateProfile } from "@/api/profile/profileApi";
 
 export default function ProfileEditPage() {
+  const router = useRouter();
+  const [form, setForm] = useState({ name: "", phone: "", region: "", intro: "" });
   const [userId, setUserId] = useState<string | null>(null);
-  const [form, setForm] = useState<ProfileForm>({
-    name: "",
-    phone: "",
-    region: "",
-    intro: "",
-  });
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
 
-  // ✅ userId 안전하게 불러오기
+  // ✅ 로그인된 사용자 정보 확인 및 프로필 불러오기
   useEffect(() => {
-    const id = localStorage.getItem("userId");
-    setUserId(id);
-  }, []);
+    const user = AuthLoginApi.getCurrentUser() ?? AuthLoginApi.restoreUserFromStorage();
 
-  // ✅ 기존 프로필 불러오기
-  useEffect(() => {
-    const fetchProfile = async () => {
-      if (!userId) return;
-      try {
-        const res = await instance.get(`/users/${userId}`);
-        setForm(res.data);
-      } catch (err) {
-        console.error("프로필 조회 실패:", err);
-      }
-    };
-    fetchProfile();
-  }, [userId]);
+    if (!user?.id) {
+      alert("로그인이 필요합니다.");
+      router.push("/login");
+      return;
+    }
 
+    setUserId(user.id);
+    fetchProfile(user.id);
+  }, [router]);
+
+  const fetchProfile = async (id: string) => {
+    try {
+      const profile = await getProfile(id);
+      setForm({
+        name: profile.name || "",
+        phone: profile.phone || "",
+        region: profile.address || "",
+        intro: profile.bio || "",
+      });
+    } catch (error) {
+      console.error("❌ 프로필 불러오기 실패:", error);
+      alert("프로필 정보를 불러올 수 없습니다.");
+      router.push("/profile/detail");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // ✅ 입력 값 변경 핸들러
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
     setForm(prev => ({ ...prev, [name]: value }));
   };
 
+  // ✅ 수정 요청
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!userId) {
-      alert("로그인 정보가 없습니다. 다시 로그인해주세요.");
-      return;
-    }
+    if (!userId) return alert("로그인 정보가 없습니다.");
 
     try {
-      const res = await instance.put(`/users/${userId}`, form);
-      console.log("프로필 수정 성공:", res.data);
+      await updateProfile(userId, form);
       setIsModalOpen(true);
     } catch (err) {
-      console.error("프로필 수정 실패:", err);
+      console.error("❌ 프로필 수정 실패:", err);
       alert("수정에 실패했습니다. 다시 시도해주세요.");
     }
   };
 
+  if (loading) return <p className="text-center mt-10">불러오는 중...</p>;
+
   return (
-    <main
-      className="
-        w-full max-w-[957px] mx-auto
-        px-5 tablet:px-6
-        pt-[40px] pb-[120px]
-        min-h-screen
-      "
-    >
+    <main className="max-w-[957px] mx-auto px-5 pt-[40px] pb-[120px]">
       <div className="relative mb-[40px]">
-        <h1 className="text-h2 text-black font-bold">내 프로필 수정</h1>
+        <h1 className="text-h2 font-bold text-black">내 프로필 수정</h1>
         <button
-          onClick={() => (window.location.href = "/profile/detail")}
+          onClick={() => router.push("/profile/detail")}
           className="absolute right-0 top-0 text-h2 text-gray-50 hover:text-black"
         >
           ✕
@@ -85,40 +82,40 @@ export default function ProfileEditPage() {
       </div>
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-[32px]">
-        <div className="grid grid-cols-1 tablet:grid-cols-3 desktop:grid-cols-3 gap-[24px]">
-          <div className="flex flex-col">
-            <label className="text-body-1-regular text-black mb-[8px]">이름*</label>
+        <div className="grid grid-cols-1 tablet:grid-cols-3 gap-[24px]">
+          <div>
+            <label className="text-body-1-regular text-black mb-[8px] block">이름*</label>
             <input
               name="name"
               value={form.name}
               onChange={handleChange}
               placeholder="입력"
-              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] focus:outline-none"
+              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] focus:outline-none w-full"
             />
           </div>
 
-          <div className="flex flex-col">
-            <label className="text-body-1-regular text-black mb-[8px]">연락처*</label>
+          <div>
+            <label className="text-body-1-regular text-black mb-[8px] block">연락처*</label>
             <input
               name="phone"
               value={form.phone}
               onChange={handleChange}
               placeholder="입력"
-              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] focus:outline-none"
+              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] focus:outline-none w-full"
             />
           </div>
 
-          <div className="flex flex-col">
-            <label className="text-body-1-regular text-black mb-[8px]">선호 지역</label>
+          <div>
+            <label className="text-body-1-regular text-black mb-[8px] block">선호 지역</label>
             <select
               name="region"
               value={form.region}
               onChange={handleChange}
-              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] bg-white focus:outline-none"
+              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] bg-white focus:outline-none w-full"
             >
               <option value="">선택</option>
               {REGION_OPTIONS.map(r => (
-                <option key={r.value} value={r.value}>
+                <option key={r.value} value={r.label}>
                   {r.label}
                 </option>
               ))}
@@ -146,13 +143,8 @@ export default function ProfileEditPage() {
 
       {isModalOpen && (
         <Modal onClose={() => setIsModalOpen(false)}>
-          <p className="text-lg font-semibold mb-6">프로필 수정이 완료되었습니다.</p>
-          <Button
-            variant="primary"
-            size="medium"
-            className="w-full"
-            onClick={() => (window.location.href = "/profile/detail")}
-          >
+          <p className="text-lg font-semibold mb-6">프로필이 수정되었습니다.</p>
+          <Button variant="primary" size="medium" className="w-full" onClick={() => router.push("/profile/detail")}>
             확인
           </Button>
         </Modal>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,57 +1,51 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
-import Button from "@/components/common/button";
-import instance from "@/api/axios";
+import { useRouter } from "next/navigation";
+import { getProfile } from "@/api/profile/profileApi";
+import { AuthLoginApi } from "@/contexts/AuthLoginApi";
 
 export default function ProfilePage() {
-  const [hasProfile, setHasProfile] = useState<boolean | null>(null);
+  const router = useRouter();
+  const [checking, setChecking] = useState(true);
 
   useEffect(() => {
+    const user = AuthLoginApi.getCurrentUser() ?? AuthLoginApi.restoreUserFromStorage();
+
+    if (!user?.id) {
+      alert("로그인이 필요합니다.");
+      router.push("/login");
+      return;
+    }
+
     const checkProfile = async () => {
       try {
-        const userId = localStorage.getItem("userId");
-        if (!userId) {
-          setHasProfile(false);
-          return;
-        }
+        const profileRes = await getProfile(user.id);
 
-        const res = await instance.get(`/users/${userId}`);
-        setHasProfile(!!res.data);
+        const hasProfile = profileRes && (profileRes.name || profileRes.phone || profileRes.address || profileRes.bio);
+
+        if (hasProfile) {
+          router.replace("/profile/detail"); // ✅ 프로필 있으면 상세페이지로
+        } else {
+          router.replace("/profile/register"); // ✅ 없으면 등록페이지로
+        }
       } catch (err) {
-        console.error("프로필 불러오기 실패:", err);
-        setHasProfile(false);
+        console.error("프로필 확인 실패:", err);
+        router.replace("/profile/register");
+      } finally {
+        setChecking(false);
       }
     };
 
     checkProfile();
-  }, []);
+  }, [router]);
 
-  if (hasProfile === null) return <p className="text-center mt-10">프로필 정보를 불러오는 중...</p>;
+  if (checking)
+    return (
+      <main className="min-h-screen flex items-center justify-center text-gray-500">
+        프로필 정보를 확인 중입니다...
+      </main>
+    );
 
-  return (
-    <main className="min-h-screen w-full max-w-[957px] mx-auto px-5 pt-[24px] pb-[96px]">
-      <h1 className="text-h2 font-bold mb-[16px]">내 프로필</h1>
-
-      {hasProfile ? (
-        <Link href="/profile/detail">
-          <Button variant="primary" size="large" className="w-[240px] h-[47px] mx-auto block">
-            내 프로필 보기
-          </Button>
-        </Link>
-      ) : (
-        <section className="border border-gray-20 rounded-[8px] bg-white py-[56px] px-[24px] text-center shadow">
-          <p className="text-body-1-regular text-gray-50 mb-[28px]">
-            내 프로필을 등록하고 원하는 가게에 지원해 보세요.
-          </p>
-          <Link href="/profile/register">
-            <Button variant="primary" size="large" className="w-[240px] h-[47px] mx-auto">
-              내 프로필 등록하기
-            </Button>
-          </Link>
-        </section>
-      )}
-    </main>
-  );
+  return null;
 }

--- a/src/app/profile/register/page.tsx
+++ b/src/app/profile/register/page.tsx
@@ -1,106 +1,85 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import Button from "@/components/common/button";
 import Modal from "@/components/common/modal/CommonModal";
-import instance from "@/api/axios";
 import { REGION_OPTIONS } from "@/constants/options";
+import { AuthLoginApi } from "@/contexts/AuthLoginApi";
+import { saveProfile } from "@/api/profile/profileApi";
 
 export default function ProfileRegisterPage() {
-  const [form, setForm] = useState({
-    name: "",
-    phone: "",
-    region: "",
-    intro: "",
-  });
+  const router = useRouter();
+  const [form, setForm] = useState({ name: "", phone: "", region: "", intro: "" });
+  const [userId, setUserId] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const userId = localStorage.getItem("userId");
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+  useEffect(() => {
+    const user = AuthLoginApi.getCurrentUser() ?? AuthLoginApi.restoreUserFromStorage();
+    if (!user?.id) {
+      alert("로그인이 필요합니다.");
+      router.push("/login");
+      return;
+    }
+    setUserId(user.id);
+  }, [router]);
+
+  const handleChange = (e: any) => {
     const { name, value } = e.target;
     setForm(prev => ({ ...prev, [name]: value }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (!userId) {
-      alert("로그인 정보가 없습니다. 다시 로그인해주세요.");
-      return;
-    }
+    if (!userId) return alert("로그인 정보가 없습니다.");
 
     try {
-      const res = await instance.put(`/users/${userId}`, form);
-      console.log("프로필 등록 성공:", res.data);
+      await saveProfile(userId, form);
       setIsModalOpen(true);
     } catch (err) {
-      console.error("프로필 등록 실패:", err);
-      alert("등록에 실패했습니다. 다시 시도해주세요.");
+      console.error("❌ 프로필 등록 실패:", err);
+      alert("등록 실패, 다시 시도해주세요.");
     }
   };
 
   return (
-    <main
-      className="
-        w-full max-w-[957px] mx-auto
-        px-5 tablet:px-6
-        pt-[40px] pb-[120px]
-        min-h-screen
-      "
-    >
-      {/* 상단 타이틀 + 닫기 버튼 */}
-      <div className="relative mb-[40px]">
-        <h1 className="text-h2 text-black font-bold">내 프로필</h1>
-        <button
-          onClick={() => (window.location.href = "/profile")}
-          className="absolute right-0 top-0 text-h2 text-gray-50 hover:text-black"
-        >
-          ✕
-        </button>
-      </div>
-
-      {/* 입력 폼 */}
-      <form
-        onSubmit={handleSubmit}
-        className="
-          flex flex-col gap-[32px]
-        "
-      >
-        {/* 이름/연락처/선호 지역 */}
-        <div className="grid grid-cols-1 tablet:grid-cols-3 desktop:grid-cols-3 gap-[24px]">
-          <div className="flex flex-col">
-            <label className="text-body-1-regular text-black mb-[8px]">이름*</label>
+    <main className="max-w-[957px] mx-auto px-5 pt-[40px] pb-[120px]">
+      <h1 className="text-h2 font-bold mb-[40px]">내 프로필 등록</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-[32px]">
+        <div className="grid grid-cols-1 tablet:grid-cols-3 gap-[24px]">
+          <div>
+            <label className="text-body-1-regular mb-[8px] block">이름*</label>
             <input
               name="name"
               value={form.name}
               onChange={handleChange}
               placeholder="입력"
-              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] focus:outline-none"
+              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] w-full"
             />
           </div>
 
-          <div className="flex flex-col">
-            <label className="text-body-1-regular text-black mb-[8px]">연락처*</label>
+          <div>
+            <label className="text-body-1-regular mb-[8px] block">연락처*</label>
             <input
               name="phone"
               value={form.phone}
               onChange={handleChange}
               placeholder="입력"
-              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] focus:outline-none"
+              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] w-full"
             />
           </div>
 
-          <div className="flex flex-col">
-            <label className="text-body-1-regular text-black mb-[8px]">선호 지역</label>
+          <div>
+            <label className="text-body-1-regular mb-[8px] block">선호 지역</label>
             <select
               name="region"
               value={form.region}
               onChange={handleChange}
-              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] bg-white focus:outline-none"
+              className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] bg-white w-full"
             >
               <option value="">선택</option>
               {REGION_OPTIONS.map(r => (
-                <option key={r.value} value={r.value}>
+                <option key={r.value} value={r.label}>
                   {r.label}
                 </option>
               ))}
@@ -108,19 +87,17 @@ export default function ProfileRegisterPage() {
           </div>
         </div>
 
-        {/* 소개 */}
         <div>
-          <label className="text-body-1-regular text-black mb-[8px] block">소개</label>
+          <label className="text-body-1-regular mb-[8px] block">소개</label>
           <textarea
             name="intro"
             value={form.intro}
             onChange={handleChange}
             placeholder="입력"
-            className="border border-gray-20 rounded-[6px] w-full p-[16px] resize-none h-[160px] focus:outline-none"
+            className="border border-gray-20 rounded-[6px] w-full p-[16px] resize-none h-[160px]"
           />
         </div>
 
-        {/* 버튼 */}
         <div className="text-center">
           <Button type="submit" variant="primary" size="large" className="w-[240px] h-[47px] mx-auto">
             등록하기
@@ -128,16 +105,10 @@ export default function ProfileRegisterPage() {
         </div>
       </form>
 
-      {/* 등록 완료 모달 */}
       {isModalOpen && (
         <Modal onClose={() => setIsModalOpen(false)}>
           <p className="text-lg font-semibold mb-6">등록이 완료되었습니다.</p>
-          <Button
-            variant="primary"
-            size="medium"
-            className="w-full"
-            onClick={() => (window.location.href = "/profile/detail")}
-          >
+          <Button variant="primary" size="medium" className="w-full" onClick={() => router.push("/profile/detail")}>
             확인
           </Button>
         </Modal>

--- a/src/components/login/LoginUi.tsx
+++ b/src/components/login/LoginUi.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import Input from "@/components/common/input/Input";
@@ -12,9 +12,11 @@ import { BaseFormData } from "@/hooks/useFormData";
 import { BaseErrors } from "@/hooks/useFormValidation";
 import { AuthLoginApi } from "@/contexts/AuthLoginApi";
 import { User } from "@/types/user";
+import { RouterProvider } from "@/contexts/AuthLoginModal";
 
 export default function LoginUi() {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   // 전역 상태 관리
   const [currentUser, setCurrentUser] = useState<User | null>(null);
@@ -23,6 +25,9 @@ export default function LoginUi() {
   // 모달 상태 관리
   const [showModal, setShowModal] = useState(false);
   const [modalMessage, setModalMessage] = useState("");
+
+  // 토큰 만료 모달 상태 관리
+  const [showTokenExpiredModal, setShowTokenExpiredModal] = useState(false);
 
   useEffect(() => {
     const unsubscribe = AuthLoginApi.subscribe(user => {
@@ -35,14 +40,20 @@ export default function LoginUi() {
     return unsubscribe;
   }, []);
 
-  // 로그인 되어있는 상태면 공고리스트로 이동시켜
+  // URL 파라미터 체크, 토큰 만료시 모달 안내
+  useEffect(() => {
+    const reason = searchParams.get("reason");
+    if (reason === "token-expired") {
+      setShowTokenExpiredModal(true);
+    }
+  }, [searchParams]);
+
   useEffect(() => {
     if (currentUser) {
       router.push("/jobs");
     }
   }, [currentUser, router]);
 
-  // 통합 폼 관리
   const {
     formData,
     errors,
@@ -59,17 +70,22 @@ export default function LoginUi() {
     },
   );
 
-  // 모달 닫기 함수
   const handleModalClose = () => {
     setShowModal(false);
     setModalMessage("");
+  };
+
+  const handleTokenExpiredModalClose = () => {
+    setShowTokenExpiredModal(false);
+    const newUrl = new URL(window.location.href);
+    newUrl.searchParams.delete("reason");
+    window.history.replaceState({}, "", newUrl.toString());
   };
 
   // 폼 입력
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     baseHandleInputChange(e);
 
-    // 모달이 열려있다면 닫기
     if (showModal) {
       setShowModal(false);
     }
@@ -109,61 +125,74 @@ export default function LoginUi() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-white px-4">
-      <div className="w-full max-w-md">
-        <div className="text-center mb-8">
-          <Link href="/jobs">
-            <Image src="/logo.svg" alt="THE JULGE 로고" width={248} height={45} className="mx-auto cursor-pointer" />
-          </Link>
-        </div>
-
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <Input
-            label="이메일"
-            type="email"
-            name="email"
-            value={formData.email}
-            placeholder="입력"
-            error={errors.email}
-            onChange={handleInputChange}
-          />
-
-          <Input
-            label="비밀번호"
-            type="password"
-            name="password"
-            value={formData.password}
-            placeholder="입력"
-            error={errors.password}
-            onChange={handleInputChange}
-          />
-
-          <Button type="submit" variant="primary" size="large" className="w-full" disabled={isLoading}>
-            {isLoading ? "로그인 중..." : "로그인 하기"}
-          </Button>
-        </form>
-
-        <div className="text-center mt-6">
-          <span className="text-black text-sm">회원이 아니신가요? </span>
-          <button
-            onClick={handleSignupClick}
-            className="text-blue-20 hover:text-blue-20/80 underline font-medium text-sm"
-          >
-            회원가입 하기
-          </button>
-        </div>
-      </div>
-
-      {showModal && (
-        <Modal onClose={handleModalClose}>
-          <div className="space-y-4">
-            <p className="text-black">{modalMessage}</p>
-            <Button onClick={handleModalClose} variant="primary" size="medium" className="w-full">
-              확인
-            </Button>
+    <RouterProvider>
+      <div className="flex flex-col items-center justify-center min-h-screen bg-white px-4">
+        <div className="w-full max-w-md">
+          <div className="text-center mb-8">
+            <Link href="/jobs">
+              <Image src="/logo.svg" alt="THE JULGE 로고" width={248} height={45} className="mx-auto cursor-pointer" />
+            </Link>
           </div>
-        </Modal>
-      )}
-    </div>
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <Input
+              label="이메일"
+              type="email"
+              name="email"
+              value={formData.email}
+              placeholder="입력"
+              error={errors.email}
+              onChange={handleInputChange}
+            />
+
+            <Input
+              label="비밀번호"
+              type="password"
+              name="password"
+              value={formData.password}
+              placeholder="입력"
+              error={errors.password}
+              onChange={handleInputChange}
+            />
+
+            <Button type="submit" variant="primary" size="large" className="w-full" disabled={isLoading}>
+              {isLoading ? "로그인 중..." : "로그인 하기"}
+            </Button>
+          </form>
+
+          <div className="text-center mt-6">
+            <span className="text-black text-sm">회원이 아니신가요? </span>
+            <button
+              onClick={handleSignupClick}
+              className="text-blue-20 hover:text-blue-20/80 underline font-medium text-sm"
+            >
+              회원가입 하기
+            </button>
+          </div>
+        </div>
+
+        {showModal && (
+          <Modal onClose={handleModalClose}>
+            <div className="space-y-4">
+              <p className="text-black">{modalMessage}</p>
+              <Button onClick={handleModalClose} variant="primary" size="medium" className="w-full">
+                확인
+              </Button>
+            </div>
+          </Modal>
+        )}
+
+        {showTokenExpiredModal && (
+          <Modal onClose={handleTokenExpiredModalClose}>
+            <div className="space-y-4">
+              <p className="text-black">로그인 세션이 만료되었습니다.</p>
+              <Button onClick={handleTokenExpiredModalClose} variant="primary" size="medium" className="w-full">
+                확인
+              </Button>
+            </div>
+          </Modal>
+        )}
+      </div>
+    </RouterProvider>
   );
 }

--- a/src/components/owner/NoticeList.tsx
+++ b/src/components/owner/NoticeList.tsx
@@ -22,7 +22,7 @@ export const NoticeList = ({ notices, hasNext, isLoading, loadMore }: NoticeList
   });
 
   const handleNoticeClick = (notice: PostData) => {
-    router.push(`/owner/notice/${notice.id}`);
+    router.push(`/owner/notice/${notice.shop.id}/${notice.id}`);
   };
 
   return (

--- a/src/components/owner/notice/ApplicationList.tsx
+++ b/src/components/owner/notice/ApplicationList.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useApplications } from "@/hooks/useApplications";
+import { ApplicationNoticeItem } from "@/types/application";
+import { ApplicantData } from "@/types/TablePropsTypes";
+import CommonTable from "@/components/common/table/CommonTableBoss";
+
+interface ApplicationListProps {
+  shopId: string;
+  noticeId: string;
+}
+
+const convertToApplicantData = (application: ApplicationNoticeItem): ApplicantData => {
+  return {
+    id: application.id,
+    name: application.user.item.name ?? "이름 없음",
+    introduction: application.user.item.bio ?? "",
+    phoneNumber: application.user.item.phone ?? "전화번호 없음",
+    status: application.status === "accepted" ? "approved" : application.status,
+  };
+};
+
+export const ApplicationList = ({ shopId, noticeId }: ApplicationListProps) => {
+  const { applications, isLoading, error, approveApplication, rejectApplication } = useApplications(shopId, noticeId);
+
+  /**
+   * 신청 승인 핸들러
+   * @param applicationId - 신청 ID
+   */
+  const handleApprove = async (applicationId: string) => {
+    try {
+      await approveApplication(applicationId);
+      alert("신청 승인 완료");
+    } catch (err) {
+      alert("승인 처리 실패");
+    }
+  };
+
+  const handleReject = async (applicationId: string) => {
+    try {
+      await rejectApplication(applicationId);
+      alert("신청 거절 완료");
+    } catch (err) {
+      alert("거절 처리 실패");
+    }
+  };
+
+  // 로딩
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-12 text-center">
+        <p className="text-body-1-regular text-gray-40">신청자 목록을 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  // 신청자가 없을 때
+  if (applications.length === 0) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-12 text-center">
+        <p className="text-body-1-regular text-gray-40">아직 신청자가 없습니다.</p>
+      </div>
+    );
+  }
+
+  // 에러 발생
+  if (error) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-12 text-center">
+        <p className="text-body-1-regular text-red-40">{error}</p>
+      </div>
+    );
+  }
+
+  // ApplicationNoticeItem[] → ApplicantData[] 변환
+  const applicantData: ApplicantData[] = applications.map(convertToApplicantData);
+
+  return <CommonTable title="" data={applicantData} onApprove={handleApprove} onReject={handleReject} />;
+};

--- a/src/components/owner/notice/NoticeInfo.tsx
+++ b/src/components/owner/notice/NoticeInfo.tsx
@@ -1,0 +1,115 @@
+import Image from "next/image";
+import Link from "next/link";
+import Button from "@/components/common/button";
+import { formatDate, formatTime } from "@/utils/date";
+import { NoticeDetailItem } from "@/types/notice";
+import { UserType } from "@/types/user";
+
+interface NoticeInfoProps {
+  noticeDetail: NoticeDetailItem;
+  userRole?: UserType;
+  onClick?: () => void;
+}
+
+export const NoticeInfo = ({ noticeDetail, userRole = "employer", onClick }: NoticeInfoProps) => {
+  const { shop, hourlyPay, startsAt, workhour, description, closed } = noticeDetail;
+
+  // 숫자를 통화 형식으로 포멧팅
+  const formatCurrency = (amoubt: number): string => {
+    return new Intl.NumberFormat("ko-KR").format(amoubt);
+  };
+
+  // 날짜 포맷팅
+  const formatDateTime = (startTime: string, workHours: number): string => {
+    const start = new Date(startTime);
+    const end = new Date(start.getTime() + workHours * 60 * 60 * 1000);
+
+    const dateStr = formatDate(start).replace(/\. /g, "-").replace(".", ""); // YYYY-MM-DD
+    const startTimeStr = formatTime(start);
+    const endTimeStr = formatTime(end);
+
+    return `${dateStr} ${startTimeStr}~${endTimeStr} (${workHours}시간)`;
+  };
+
+  const calculateIncreaseRate = (): number => {
+    if (!shop.item.originalHourlyPay || shop.item.originalHourlyPay === 0) return 0;
+    return Math.round(((hourlyPay - shop.item.originalHourlyPay) / shop.item.originalHourlyPay) * 100);
+  };
+  const increaseRate = calculateIncreaseRate();
+
+  return (
+    <div className="w-full">
+      <div className=" border border-gray-20 rounded-xl">
+        <div className="flex w-full bg-white p-6 gap-[30px] rounded-xl">
+          {/* 가게 이미지 */}
+          <div className="relative w-[539px] h-[309px]">
+            <Image src={shop.item.imageUrl} alt={shop.item.name} fill className="object-cover rounded-xl" priority />
+          </div>
+
+          {/* 공고 정보 */}
+          <div className="w-[346px] pt-4 flex flex-col justify-between gap-3 grow-0">
+            {/* 공고 시급 */}
+            <div>
+              <span className="text-body-1-bold text-primary-20">시급</span>
+              <div className="flex items-center gap-3">
+                <span className="text-h1">{formatCurrency(hourlyPay)}원</span>
+                {increaseRate > 0 && (
+                  <span className="px-4 py-3  bg-primary-20 text-white text-body-2-bold rounded-full">
+                    기존 시급보다 {increaseRate}% ↑
+                  </span>
+                )}
+              </div>
+            </div>
+            {/* 근무 닐짜 / 시간 */}
+            <div className="flex gap-1.5 text-body-1-regular items-center">
+              <Image
+                src="/clock.svg"
+                width={20}
+                height={20}
+                alt="시간 아이콘"
+                style={{ width: "20px", height: "20px" }}
+              />
+              <span className="text-gray-50 text-body-1-regular">{formatDateTime(startsAt, workhour)}</span>
+            </div>
+            {/* 주소 */}
+            <div className="text-body-1-regular">
+              <div className=" flex gap-1 items-center">
+                <Image
+                  src="/Location.svg"
+                  width={20}
+                  height={20}
+                  alt="시간 아이콘"
+                  style={{ width: "20px", height: "20px" }}
+                />
+                <span className="text-gray-50 text-body-1-regular">
+                  {shop.item.address1} {shop.item.address2}
+                </span>
+              </div>
+            </div>
+            {/* 가게 설명 */}
+            <div className="mb-4 grow">
+              <p className="text-body-1-regular line-clamp-3">{shop.item.description}</p>
+            </div>
+
+            {/* 버튼 */}
+            <div className="w-full flex gap-2">
+              <div className="w-full">
+                <Link href={`/owner/edit-shop/${shop.item.id}`}>
+                  <Button variant="outlined" className=" w-full" size="large">
+                    편집하기
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 공고 설명 */}
+      <div className="w-full bg-gray-10 mt-6 p-8 rounded-xl">
+        <span className="text-body-1-bold text-black mb-3">공고 설명</span>
+        <p className="text-body-1-regular line-clamp-3">{shop.item.description}</p>
+      </div>
+    </div>
+  );
+};

--- a/src/contexts/AuthLoginApi.tsx
+++ b/src/contexts/AuthLoginApi.tsx
@@ -2,7 +2,7 @@
 
 import { User, LoginResponse } from "@/types/user";
 import { loginUser } from "@/api/login/LoginApi";
-import { AuthLoginModal } from "@/contexts/AuthLoginModal";
+import { handleTokenExpiry } from "@/contexts/AuthLoginModal";
 
 // 상태 변경 리스너 타입
 type AuthStateListener = (user: User | null) => void;
@@ -10,7 +10,7 @@ type AuthStateListener = (user: User | null) => void;
 export class AuthLoginApi {
   private static listeners: AuthStateListener[] = [];
   private static currentUser: User | null = null;
-  private static readonly TOKEN_EXPIRY_MINUTES = 5; // 분 단위로 토큰 유효시간 설정가능
+  private static readonly TOKEN_EXPIRY_MINUTES = 1; // 분 단위로 토큰 유효시간 설정가능
 
   // 상태 변경 리스너 등록/해제
   static subscribe(listener: AuthStateListener): () => void {
@@ -24,13 +24,11 @@ export class AuthLoginApi {
     };
   }
 
-  // 상태 변경 알림
   private static notifyListeners(user: User | null): void {
     this.currentUser = user;
     this.listeners.forEach(listener => listener(user));
   }
 
-  // 현재 사용자 정보 가져오기
   static getCurrentUser(): User | null {
     return this.currentUser;
   }
@@ -49,7 +47,7 @@ export class AuthLoginApi {
     // 만료 시간 이후 토큰 무효
     if (now > expirationTime) {
       this.executeLogout();
-      AuthLoginModal.showTokenExpiredModal();
+      handleTokenExpiry(); // 로그인 페이지로 이동
       return false;
     }
     return true;
@@ -116,7 +114,7 @@ export class AuthLoginApi {
         return null;
       }
     }
-    // 저장된 정보가 없으면 null
+
     this.notifyListeners(null);
     return null;
   }
@@ -126,10 +124,5 @@ export class AuthLoginApi {
     localStorage.removeItem("userId");
     localStorage.removeItem("user");
     this.notifyListeners(null);
-
-    // 토큰 만료로 인한 로그아웃 체크
-    if (this.currentUser) {
-      AuthLoginModal.showTokenExpiredModal();
-    }
   }
 }

--- a/src/contexts/AuthLoginModal.tsx
+++ b/src/contexts/AuthLoginModal.tsx
@@ -1,47 +1,40 @@
 "use client";
 
-import { createRoot } from "react-dom/client";
-import Button from "@/components/common/button";
+import { createContext, useContext, ReactNode } from "react";
+import { useRouter } from "next/navigation";
+
+// 라우터 인스턴스 전역관리
+const RouterContext = createContext<ReturnType<typeof useRouter> | null>(null);
+
+// Router Provider 컴포넌트
+export const RouterProvider = ({ children }: { children: ReactNode }) => {
+  const router = useRouter();
+  return <RouterContext.Provider value={router}>{children}</RouterContext.Provider>;
+};
+
+export const useGlobalRouter = () => {
+  const router = useContext(RouterContext);
+  if (!router) {
+    throw new Error("useGlobalRouter must be used within RouterProvider");
+  }
+  return router;
+};
+
+export const handleTokenExpiry = (): void => {
+  try {
+    const router = useGlobalRouter();
+    router.push("/login?reason=token-expired");
+  } catch (error) {
+    // router가 없으면 window.location 사용
+    console.warn("Router not available, falling back to window.location");
+    window.location.href = "/login?reason=token-expired";
+  }
+};
 
 export class AuthLoginModal {
   static showTokenExpiredModal(): void {
-    // 모달 중복표시 방지
-    if (document.getElementById("token-expired-modal")) {
-      return;
-    }
-
-    const modalContainer = document.createElement("div");
-    modalContainer.id = "token-expired-modal";
-    document.body.appendChild(modalContainer);
-
-    const root = createRoot(modalContainer);
-    root.render(
-      <div className="fixed inset-0 z-50 bg-black bg-opacity-40 flex items-center justify-center">
-        <div className="bg-white p-8 rounded-xl shadow-lg w-[320px] text-center relative">
-          <div className="space-y-4">
-            <p className="text-black">로그인 세션이 만료되었습니다.</p>
-            <Button
-              variant="primary"
-              size="medium"
-              className="w-full"
-              onClick={() => {
-                root.unmount();
-                document.body.removeChild(modalContainer);
-                window.location.href = "/login";
-              }}
-            >
-              확인
-            </Button>
-          </div>
-        </div>
-      </div>,
-    );
+    handleTokenExpiry();
   }
 
-  static removeModal(): void {
-    const modalContainer = document.getElementById("token-expired-modal");
-    if (modalContainer) {
-      modalContainer.remove();
-    }
-  }
+  static removeModal(): void {}
 }

--- a/src/hooks/useApplications.ts
+++ b/src/hooks/useApplications.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ApplicationNoticeItem } from "@/types/application";
+import { getNoticeApplications, putNoticeApplications } from "@/api/application/ApplicationApi";
+
+interface UseApplicationsData {
+  applications: ApplicationNoticeItem[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+  approveApplication: (applicationId: string) => Promise<void>;
+  rejectApplication: (applicationId: string) => Promise<void>;
+}
+
+export const useApplications = (shopId: string | null, noticeId: string | null): UseApplicationsData => {
+  const [applications, setApplications] = useState<ApplicationNoticeItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 신청자 목록 패칭
+  const fetchApplications = useCallback(async () => {
+    if (!shopId || !noticeId) {
+      setApplications([]);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await getNoticeApplications(shopId, noticeId);
+
+      const applicationItems = response.items.map(info => info.item);
+      setApplications(applicationItems);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "신청자 목록을 불러오는데 실패했습니다.";
+      setError(message);
+      setApplications([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [shopId, noticeId]);
+
+  // 신청 승인
+  const approveApplication = async (applicationId: string) => {
+    if (!shopId || !noticeId) return;
+
+    try {
+      await putNoticeApplications(shopId, noticeId, applicationId, {
+        status: "accepted",
+      });
+
+      setApplications(prev =>
+        prev.map(app => (app.id === applicationId ? { ...app, status: "accepted" as const } : app)),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "승인 처리에 실패했습니다.";
+      setError(message);
+      throw err;
+    }
+  };
+
+  // 신청 거절
+
+  const rejectApplication = async (applicationId: string) => {
+    if (!shopId || !noticeId) return;
+
+    try {
+      await putNoticeApplications(shopId, noticeId, applicationId, {
+        status: "rejected",
+      });
+
+      setApplications(prev =>
+        prev.map(app => (app.id === applicationId ? { ...app, status: "rejected" as const } : app)),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "거절 처리에 실패했습니다.";
+      setError(message);
+      throw err;
+    }
+  };
+
+  useEffect(() => {
+    fetchApplications();
+  }, [fetchApplications]);
+
+  return {
+    applications,
+    isLoading,
+    error,
+    refetch: fetchApplications,
+    approveApplication,
+    rejectApplication,
+  };
+};

--- a/src/hooks/useShopNoticeDetail.ts
+++ b/src/hooks/useShopNoticeDetail.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getShopNotice } from "@/api/notice/NoticeApi";
+import { NoticeDetailItem } from "@/types/notice";
+
+interface useShopNoticeDetailData {
+  noticeDetail: NoticeDetailItem | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export const useShopNoticeDetail = (shopId: string | null, noticeId: string | null): useShopNoticeDetailData => {
+  const [noticeDetail, setNoticeDetail] = useState<NoticeDetailItem | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 공고 상세 정보 함수
+  const fetchNoticeDetail = async () => {
+    if (!shopId || !noticeId) {
+      setNoticeDetail(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await getShopNotice(shopId, noticeId);
+
+      setNoticeDetail(response.item);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "공고 정보를 불러오는데 실패했습니다.";
+      setError(message);
+      setNoticeDetail(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchNoticeDetail();
+  }, [shopId, noticeId]);
+
+  return {
+    noticeDetail,
+    isLoading,
+    error,
+    refetch: fetchNoticeDetail,
+  };
+};

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -1,0 +1,61 @@
+import { LinkInfo } from "@/types/links";
+import { NoticeInfo } from "@/types/notice";
+import { ShopInfomation } from "@/types/shop";
+import { User } from "@/types/user";
+
+export type ApplicationStatus = "pending" | "accepted" | "rejected" | "canceled";
+
+export interface Application {
+  id: string;
+  status: "pending" | "accepted" | "rejected";
+  createdAt: string;
+}
+
+export interface ApplicationUserItem extends Application {
+  shop: ShopInfomation;
+  notice: NoticeInfo;
+}
+
+export interface ApplicationNoticeItem extends Application {
+  user: {
+    item: User;
+    href: string;
+  };
+}
+
+export interface ApplicationUserInfo {
+  item: ApplicationUserItem;
+  links: LinkInfo[];
+}
+
+// POST - 가게의 특정 공고 지원 등록 Response
+// PUT - 가게의 특정 공고 지원 승인, 거절, 취소 Response
+export interface ApplicationNoticeInfo {
+  item: ApplicationNoticeItem;
+  links: LinkInfo[];
+}
+
+// GET - 유저의 지원 목록 조회 Response
+export interface ApplicationUserResponse {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: ApplicationUserInfo[];
+  links: LinkInfo[];
+}
+
+// GET - 가게의 특정 공고의 지원 목록 조회 Response
+export interface ApplicationNoticeResponse {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: ApplicationNoticeInfo[];
+  links: LinkInfo[];
+}
+
+// PUT - 가게의 특정 공고 지원 승인, 거절, 취소 Request
+export interface ApplicationRequest {
+  status: Exclude<ApplicationStatus, "pending">; // pending 제외
+}

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -1,5 +1,5 @@
 import { ShopInfomation } from "@/types/shop";
-import { Application } from "@/types/notification";
+import { Application } from "@/types/application";
 import { LinkInfo } from "@/types/links";
 
 export interface Notice {

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,15 +1,6 @@
 import { ShopItem } from "@/types/shop";
 import { Notice } from "@/types/notice";
-
-export interface Application {
-  id: string;
-  status: "pending" | "accepted" | "rejected";
-}
-
-export interface ApplicationInfo {
-  item: Application;
-  href: string;
-}
+import { Application } from "@/types/application";
 
 export interface NotificationItem {
   id: string;


### PR DESCRIPTION
**이전에 올린 사용자 경고 모달 관련해서 리뷰해주신 피드백을 확인하고 코드에 적용했습니다**

1. 서연님 코드리뷰
  - document.getElementById로 리액트 토큰 직접 조작방식에 대해 다른 방법으로 변경하면 좋을 것 같다는 의견

-> 해당 피드백 이후 인증토큰 만료시 동작하는 구조를 변경
  - 로그인 이후 엑세스 토큰을 받아 사용자가 사용중
  - 새로고침, 라우트 이동 등의 동작 발생시 엑세스토큰 만료시간 체크하여 유효시간이 만료되었다면
  - 로그인 페이지로 먼저 이동한 다음 모달로 로그인 세션 만료 안내
이렇게 하면 사용자는 이용중 갑자기 로그인 화면으로 넘어가지고 1초 내외의 시간에 모달로 로그인 세션 만료 안내를 받게되어서
사용자 경험은 조금 불편해지지만 코드안정성 부분을 개선

2. 원선님 코드리뷰
  - window.location.href를 사용할 경우 전체 페이지가 새로고침 되면서 리렌더링 되는 문제가 있어서 
     next.js에서 제공하는 라우팅 최적화 제공을 받을 수 있는 useRouter로 코드 변경 의견

-> window.location.href를 사용할 경우 구현이 간단하고 브라우저 네이티브 동작으로 토큰 만료 안내는 어떤 페이지에서도 감지가
     가능해야 한다는 생각을 가지고 이 부분을 중점으로 생각했습니다
      다반 next.js를 학습하는 것이 프로젝트의 목적이므로 라우팅 최적화를 위해 useRouter로 코드를 수정

      **현재는 토큰만료를 로그인 이후 지정한 시간만큼만 유지되고 자동연장, 수동연장 등의 기능이 없기때문에 동작은 이전과 동일하게
      동작합니다**


-------------------------------------------------------------------
이후에 머지된 dev 파일을 최신화하였습니다
