### PR TITLE
[추가] 편집 모드 구현, 알림 API 연동

### DIFF
--- a/src/app/(dashboard)/owner/register-notice/page.tsx
+++ b/src/app/(dashboard)/owner/register-notice/page.tsx
@@ -6,11 +6,28 @@ import Input from "@/components/common/input/Input";
 import { useAuth } from "@/hooks/useAuth";
 import { useUserData } from "@/hooks/useUserData";
 import { useNoticeForm } from "@/hooks/useNoticeForm";
+import { useSearchParams } from "next/navigation";
+import { useShopNoticeDetail } from "@/hooks/useShopNoticeDetail";
 
 export default function NoticeRegisterPage() {
+  const searchParams = useSearchParams();
+
+  // 쿼리 파라미터 mode 확인
+  const mode = searchParams.get("mode") === "edit" ? "edit" : "new";
+  const noticeIdFromQuery = searchParams.get("noticeId");
+  const shopIdFromQuery = searchParams.get("shopId");
+
   const { user } = useAuth();
   const { userData } = useUserData(user?.id);
-  const shopId = userData?.shop?.item?.id ?? null;
+
+  const shopId = mode === "new" ? userData?.shop?.item?.id ?? null : shopIdFromQuery;
+
+  // 편집 모드일 때 기존 공고 데이터 가져오기
+  const {
+    noticeDetail,
+    isLoading: isLoadingNotice,
+    error: noticeError,
+  } = useShopNoticeDetail(mode === "edit" ? shopId : null, mode === "edit" ? noticeIdFromQuery : null);
 
   const {
     formData,
@@ -24,10 +41,43 @@ export default function NoticeRegisterPage() {
     handleDateBlur,
     handleSubmit,
     handleClose,
-  } = useNoticeForm({ shopId });
+  } = useNoticeForm({
+    shopId,
+    mode,
+    noticeId: mode === "edit" ? noticeIdFromQuery : null,
+    initialData: mode === "edit" ? noticeDetail : null,
+  });
 
+  // 편집 모드에서 공고 정보 로딩 중
+  if (mode === "edit" && isLoadingNotice) {
+    return (
+      <main className="w-full max-w-[964px] mx-auto my-[3.75rem] px-8 flex items-center justify-center">
+        <p className="text-body-1-regular text-gray-40">공고 정보를 불러오는 중...</p>
+      </main>
+    );
+  }
+
+  // 편집 모드에서 공고 정보 로딩 실패
+  if (mode === "edit" && (noticeError || !noticeDetail)) {
+    return (
+      <main className="w-full max-w-[964px] mx-auto my-[3.75rem] px-8">
+        <div className="w-full mb-4 p-4 bg-red-10 border border-red-40 rounded-lg text-red-40">
+          {noticeError || "공고 정보를 찾을 수 없습니다."}
+        </div>
+        <Button onClick={handleClose} variant="primary">
+          돌아가기
+        </Button>
+      </main>
+    );
+  }
+
+  // 에러 표시
   if (error) {
-    return <div className="w-full mb-4 p-4 bg-red-10 border border-red-40 rounded-lg text-red-40">{error}</div>;
+    return (
+      <main className="w-full max-w-[964px] mx-auto my-[3.75rem] px-8">
+        <div className="w-full mb-4 p-4 bg-red-10 border border-red-40 rounded-lg text-red-40">{error}</div>
+      </main>
+    );
   }
 
   return (
@@ -115,7 +165,7 @@ export default function NoticeRegisterPage() {
           {/* 제출 버튼 */}
           <div className="col-start-2">
             <Button variant="primary" className="w-full" size="large" type="submit" disabled={isLoading}>
-              {isLoading ? "등록 중..." : "등록하기"}
+              {isLoading ? (mode === "edit" ? "수정 중..." : "등록 중...") : mode === "edit" ? "수정하기" : "등록하기"}
             </Button>
           </div>
         </div>

--- a/src/components/common/gnb/notification/NotificationCard.tsx
+++ b/src/components/common/gnb/notification/NotificationCard.tsx
@@ -17,7 +17,7 @@ const formatTimestamp = (timestamp: string) => {
 // 알림 메시지 생성
 
 const getNotificationMessage = (notification: NotificationItem) => {
-  const { shop, notice, result } = notification.item;
+  const { shop, notice, result } = notification;
 
   // 날짜 포맷팅: 2025-10-05T09:00:00Z -> 2025-10-05 09:00
   const startDate = new Date(notice.item.startsAt);
@@ -68,18 +68,17 @@ interface NotificationCardProps {
 }
 
 const NotificationCard: React.FC<NotificationCardProps> = ({ notification, onClick }) => {
-  const { item } = notification;
-  const { dotColor } = getResultStyles(item.result);
+  const { dotColor } = getResultStyles(notification.result);
   const message = getNotificationMessage(notification);
   return (
     <button
-      key={item.id}
+      key={notification.id}
       onClick={() => onClick(notification)}
       className="flex flex-col gap-1 bg-white px-3 py-4 rounded-[5px] text-left border-solid border-[1px] border-gray-20"
     >
-      {!item.read && <div className={`w-[5px] h-[5px] ${dotColor} rounded-full`} />}
-      <p className="text-body-2-regular">{highlightResult(message, item.result)}</p>
-      <p className="text-caption text-gray-40">{formatTimestamp(item.createdAt)}</p>
+      {!notification.read && <div className={`w-[5px] h-[5px] ${dotColor} rounded-full`} />}
+      <p className="text-body-2-regular">{highlightResult(message, notification.result)}</p>
+      <p className="text-caption text-gray-40">{formatTimestamp(notification.createdAt)}</p>
     </button>
   );
 };

--- a/src/components/common/gnb/notification/NotificationDropdown.tsx
+++ b/src/components/common/gnb/notification/NotificationDropdown.tsx
@@ -21,14 +21,14 @@ const NotificationDropDown = ({ onClose }: DropdownProps) => {
   });
 
   const handleNotificationClick = async (notification: NotificationItem) => {
-    if (!notification.item.read) {
+    if (!notification.read) {
       try {
-        await markAsRead(notification.item.id);
+        await markAsRead(notification.id);
       } catch (err) {
         throw new Error("읽은 알림을 처리하는데 실패했습니다.");
       }
     }
-    router.push(notification.item.notice.href);
+    router.push(notification.notice.href);
 
     onClose();
   };
@@ -64,7 +64,7 @@ const NotificationDropDown = ({ onClose }: DropdownProps) => {
             {notifications.map(notification => (
               <NotificationCard
                 key={notification.item.id}
-                notification={notification}
+                notification={notification.item}
                 onClick={handleNotificationClick}
               />
             ))}

--- a/src/components/owner/notice/NoticeInfo.tsx
+++ b/src/components/owner/notice/NoticeInfo.tsx
@@ -3,16 +3,14 @@ import Link from "next/link";
 import Button from "@/components/common/button";
 import { formatDate, formatTime } from "@/utils/date";
 import { NoticeDetailItem } from "@/types/notice";
-import { UserType } from "@/types/user";
 
 interface NoticeInfoProps {
   noticeDetail: NoticeDetailItem;
-  userRole?: UserType;
   onClick?: () => void;
 }
 
-export const NoticeInfo = ({ noticeDetail, userRole = "employer", onClick }: NoticeInfoProps) => {
-  const { shop, hourlyPay, startsAt, workhour, description, closed } = noticeDetail;
+export const NoticeInfo = ({ noticeDetail, onClick }: NoticeInfoProps) => {
+  const { shop, hourlyPay, startsAt, workhour, description, id } = noticeDetail;
 
   // 숫자를 통화 형식으로 포멧팅
   const formatCurrency = (amoubt: number): string => {
@@ -94,9 +92,9 @@ export const NoticeInfo = ({ noticeDetail, userRole = "employer", onClick }: Not
             {/* 버튼 */}
             <div className="w-full flex gap-2">
               <div className="w-full">
-                <Link href={`/owner/edit-shop/${shop.item.id}`}>
-                  <Button variant="outlined" className=" w-full" size="large">
-                    편집하기
+                <Link href={`/owner/register-notice?mode=edit&shopId=${shop.item.id}&noticeId=${id}`}>
+                  <Button variant="outlined" className=" w-full" size="large" disabled={closed}>
+                    {closed ? "마감 완료" : "편집하기"}
                   </Button>
                 </Link>
               </div>
@@ -108,7 +106,7 @@ export const NoticeInfo = ({ noticeDetail, userRole = "employer", onClick }: Not
       {/* 공고 설명 */}
       <div className="w-full bg-gray-10 mt-6 p-8 rounded-xl">
         <span className="text-body-1-bold text-black mb-3">공고 설명</span>
-        <p className="text-body-1-regular line-clamp-3">{shop.item.description}</p>
+        <p className="text-body-1-regular line-clamp-3">{description}</p>
       </div>
     </div>
   );

--- a/src/hooks/useNoticeForm.ts
+++ b/src/hooks/useNoticeForm.ts
@@ -1,6 +1,6 @@
-import { useState, ChangeEvent, FocusEvent, FormEvent } from "react";
+import { useState, ChangeEvent, FocusEvent, FormEvent, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { postShopNotice } from "@/api/notice/NoticeApi";
+import { postShopNotice, putShopNotice } from "@/api/notice/NoticeApi";
 import {
   NoticeFormData,
   NoticeValidationErrors,
@@ -10,12 +10,45 @@ import {
   validateWorkhour,
   hasValidationErrors,
 } from "@/hooks/useNoticeValidation";
+import { NoticeDetailItem } from "@/types/notice";
+
+type FormMode = "new" | "edit";
 
 interface UseNoticeFormProps {
   shopId: string | null;
+  mode?: FormMode;
+  noticeId?: string | null;
+  initialData?: NoticeDetailItem | null;
 }
 
-export const useNoticeForm = ({ shopId }: UseNoticeFormProps) => {
+interface UseNoticeFormReturn {
+  mode: FormMode;
+  formData: NoticeFormData;
+  validationErrors: NoticeValidationErrors;
+  dateInputType: "text" | "datetime-local";
+  isLoading: boolean;
+  error: string | null;
+  handleInputChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  handleInputBlur: (e: FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  handleDateFocus: (e: FocusEvent<HTMLInputElement>) => void;
+  handleDateBlur: (e: FocusEvent<HTMLInputElement>) => void;
+  handleSubmit: (e: FormEvent<HTMLFormElement>) => Promise<void>;
+  handleClose: () => void;
+}
+
+/**
+ * 공고 등록 및 편집 통합+
+ * @param mode - "new"(등록) or "edit"(편집)
+ * @param shopId - 가게 ID
+ * @param noticeId - 공고 ID (편집 모드에서만 필요)
+ * @param initialData - 초기 데이터 (편집 모드에서만 필요)
+ */
+export const useNoticeForm = ({
+  shopId,
+  mode = "new",
+  noticeId,
+  initialData,
+}: UseNoticeFormProps): UseNoticeFormReturn => {
   const router = useRouter();
 
   const [formData, setFormData] = useState<NoticeFormData>({
@@ -35,6 +68,25 @@ export const useNoticeForm = ({ shopId }: UseNoticeFormProps) => {
   const [dateInputType, setDateInputType] = useState<"text" | "datetime-local">("text");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (mode === "edit" && initialData) {
+      // ISO 문자열을 datetime-local 형식으로 변환
+      const formattedDate = initialData.startsAt ? new Date(initialData.startsAt).toISOString().slice(0, 16) : "";
+
+      setFormData({
+        hourlyPay: String(initialData.hourlyPay),
+        startsAt: formattedDate,
+        workhour: String(initialData.workhour),
+        description: initialData.description,
+      });
+
+      // 날짜가 있으면 datetime-local 타입으로 설정
+      if (formattedDate) {
+        setDateInputType("datetime-local");
+      }
+    }
+  }, [mode, initialData]);
 
   /**
    * 입력값 변경 핸들러
@@ -118,35 +170,53 @@ export const useNoticeForm = ({ shopId }: UseNoticeFormProps) => {
       return;
     }
 
+    // 편집 모드일 때 noticeId 확인
+    if (mode === "edit" && !noticeId) {
+      setError("공고 정보가 없습니다.");
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
 
     try {
       const formattedStartsAt = new Date(formData.startsAt).toISOString();
-
-      await postShopNotice(shopId, {
+      const requestBody = {
         hourlyPay: Number(formData.hourlyPay),
         startsAt: formattedStartsAt,
         workhour: Number(formData.workhour),
         description: formData.description || "공고 설명이 없습니다.",
-      });
+      };
 
-      router.push("/owner");
+      if (mode === "edit" && noticeId) {
+        // 편집 모드 - PUT 요청
+        await putShopNotice(shopId, noticeId, requestBody);
+        router.push(`/owner/notice/${shopId}/${noticeId}`);
+      } else {
+        // 등록 모드: POST 요청
+        await postShopNotice(shopId, requestBody);
+        router.push(`/shops/notice/${shopId}/${noticeId}`);
+      }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "공고 등록에 실패했습니다.");
+      const message =
+        err instanceof Error
+          ? err.message
+          : mode === "edit"
+          ? "공고 수정에 실패했습니다."
+          : "공고 등록에 실패했습니다.";
+      setError(message);
     } finally {
       setIsLoading(false);
     }
   };
 
-  /**
-   * 닫기 핸들러
-   */
+  // 닫기 핸들러
   const handleClose = () => {
     router.back();
   };
 
   return {
+    mode,
     formData,
     validationErrors,
     dateInputType,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@/hooks/useAuth";
-import { NotificationItem } from "@/types/notification";
+import { NotificationInfo } from "@/types/notification";
 import { useInfinitePagination } from "@/hooks/useInfinitePagination";
 import { getAlerts, putAlerts } from "@/api/alert/AlertsApi";
 
@@ -35,7 +35,7 @@ export const useNotifications = () => {
     loadMore,
     refresh,
     reset,
-  } = useInfinitePagination<NotificationItem>({
+  } = useInfinitePagination<NotificationInfo>({
     fetchFunction: fetchNotifications,
     limit: ITEMS_LIMIT,
   });

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,31 +1,46 @@
 import { ShopItem } from "@/types/shop";
 import { Notice } from "@/types/notice";
 import { Application } from "@/types/application";
+import { LinkInfo } from "./links";
 
 export interface NotificationItem {
   id: string;
   createdAt: string; // 생성 시간
   result: "accepted" | "rejected"; // 지원 결과
   read: boolean; // 읽음 여부
-  application: Application; // 지원서 정보
-  shop: ShopItem; // 가게 정보
-  notice: Notice; // 공고 정보
+  application: {
+    item: Application;
+    href: string;
+  }; // 지원서 정보
+  shop: {
+    item: ShopItem;
+    href: string;
+  }; // 가게 정보
+  notice: {
+    item: Notice;
+    href: string;
+  }; // 공고 정보
 }
 
-// 알림 목록 조회
+export interface NotificationInfo {
+  item: NotificationItem;
+  links: LinkInfo[];
+}
+
+// GET - 알림 목록 조회
 export interface NotificationListResponse {
   offset: number; //  페이지네이션 시작
   limit: number; // 페이지당 개수
   count: number; // 전체 알림 개수
   hasNext: boolean; //  다음 페이지 존재 여부
-  items: NotificationItem[]; // 알림 목록
-  links: unknown[];
+  items: NotificationInfo[]; // 알림 목록
+  links: LinkInfo[];
 }
 
-// 알림 읽음 처리
+// PUT - 알림 읽음 처리
 export interface NotificationReadResponse {
   offset: number;
   linmit: number;
-  items: NotificationItem[];
-  links: unknown[];
+  items: NotificationInfo[];
+  links: LinkInfo[];
 }


### PR DESCRIPTION
# 개요

공고 상세 페이지에서 편집하기 버튼 클릭시 편집모드로 변하여 편집 되도록 구현하였습니다.
알림 API 연동해서 알바 유저는 지원 신청하고 승인, 거절 데이터가 알림이 오게끔 구현했습니다.

# 변경 사항

### `src/app/(dashboard)/owner/register-notice/page.tsx` - 공고 등록 페이지
- 쿼리 파라미터를 적용시켜 edit_mode url이 추가되며 편집모드가 동작할 수 있게 바꿨습니다.

### `src/components/common/gnb/notification/NotificationCard.tsx` - 알림 카드 파일
- 타입 정의 변경으로 경로 재설정

### `src/components/common/gnb/notification/NotificationDropdown.tsx` - 알림 드롭다운 파일
- 타입 정의 변경으로 경로 재설정

### `src/components/owner/notice/NoticeInfo.tsx` -  공고 상세 정보 컴포넌트 파일
- useRoutor로 편집하기 URL 경로 변경

### `src/hooks/useNoticeForm.ts` - 공고 등록 폼
- 편집모드 일때 PUT 요청

### `src/hooks/useNotifications.ts` - 알림 훅
- interface 변경

### `src/types/notification.ts` - 알림 타입
- 알림 API에 맞게 타입 정의 하였습니다.

| 알림 |
| --- |
|<img width="1127" height="862" alt="스크린샷 2025-10-20 오후 12 32 16" src="https://github.com/user-attachments/assets/5abf5c9c-eb04-4f56-aa5b-11667eb31576" />|

| 편집 전 | 편집 중 | 편집 후 |
| --- | --- | --- |
|<img width="1680" height="907" alt="스크린샷 2025-10-20 오후 3 16 13" src="https://github.com/user-attachments/assets/a542c2e3-deab-4992-bf06-4a474ea0f4a7" />|<img width="1680" height="907" alt="스크린샷 2025-10-20 오후 3 16 35" src="https://github.com/user-attachments/assets/49ed213e-32d7-49d5-9dc7-8ecf5acc3f3e" />|<img width="1680" height="907" alt="스크린샷 2025-10-20 오후 3 16 45" src="https://github.com/user-attachments/assets/42bcb9df-96ac-47f0-a5a7-f5b5e62484ae" />|




# 추가 작업분(순서)

1. 가게 등록(편집모드) 구현
2. 페이지네이션 연결
3. 페이지 먼저 구현 후 반응형을 구현
4. 모달(토스트) 연동