### PR TITLE
[추가] 검색 페이지 구현

### DIFF
--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -40,7 +40,6 @@ export default function Page() {
 
   return (
     <div className="min-h-screen bg-gray-5">
-      {/* 맞춤 공고 섹션 */}
       <RecommendedSection
         userLoggedIn={userLoggedIn}
         recLoading={recLoading}
@@ -53,9 +52,7 @@ export default function Page() {
         onRetry={fetchRecommendedPosts}
       />
 
-      {/* 전체 공고 영역 */}
       <div className="max-w-[994px] mx-auto px-4 py-8">
-        {/* 헤더 */}
         <PostsHeader
           sortOption={sortOption}
           isFilterOpen={isFilterOpen}
@@ -67,7 +64,6 @@ export default function Page() {
           appliedFilters={appliedFilters}
         />
 
-        {/* 공고 그리드 */}
         <PostsGrid
           posts={posts}
           loading={loading}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from "react";
+import React from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import PostsHeader from "@/components/jobs/PostsHeader";
 import PostsGrid from "@/components/jobs/PostsGrid";
-import { getNotices } from "@/api/notice/NoticeApi";
-import { PostData } from "@/types/post";
-import { parsePostsResponse } from "@/utils/api";
-import { isPostClosed } from "@/utils/post";
-import { FilterOptions, convertFilterOptionsToApiParams } from "@/types/filter";
+import { useJobPosts } from "@/hooks/useJobPosts";
 
 const ITEMS_PER_PAGE = 9;
 
@@ -16,89 +12,31 @@ const SearchPage = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const keyword = searchParams.get("keyword") ?? "";
-  const [allPosts, setAllPosts] = useState<PostData[]>([]);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [sortOption, setSortOption] = useState("time");
-  const [isFilterOpen, setIsFilterOpen] = useState(false);
-  const [appliedFilters, setAppliedFilters] = useState<FilterOptions>({});
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  // 검색 실행 함수
-  const handleSearch = useCallback(async () => {
-    if (!keyword.trim()) {
-      setAllPosts([]);
-      setError(null);
-      return;
-    }
+  // useJobPosts 훅 사용 (keyword 전달)
+  const {
+    sortOption,
+    currentPage,
+    isFilterOpen,
+    appliedFilters,
+    posts: pageItems,
+    totalItems,
+    loading,
+    error,
+    handleSortChange,
+    handleFilterClick,
+    handleFilterClose,
+    handleFilterApply,
+    handleFilterReset,
+    handlePostClick,
+    handlePageChange,
+    fetchPosts,
+  } = useJobPosts({
+    keyword,
+    isSearchPage: true,
+  });
 
-    setLoading(true);
-    setError(null);
-    setCurrentPage(1);
-
-    try {
-      const apiParams = convertFilterOptionsToApiParams(appliedFilters);
-
-      const response = await getNotices({
-        offset: 0,
-        limit: 100,
-        keyword,
-        address: apiParams.address,
-        startsAtGte: apiParams.startsAtGte,
-        hourlyPayGte: apiParams.hourlyPayGte,
-        sort: sortOption as "time" | "pay" | "hour" | "shop",
-      });
-
-      // API 응답 파싱
-      const parsedPosts = parsePostsResponse(response.items || response);
-
-      const { activePosts, closedPosts } = parsedPosts.reduce(
-        (acc, post) => {
-          if (isPostClosed(post)) {
-            acc.closedPosts.push(post);
-          } else {
-            acc.activePosts.push(post);
-          }
-          return acc;
-        },
-        { activePosts: [] as PostData[], closedPosts: [] as PostData[] },
-      );
-
-      setAllPosts([...activePosts, ...closedPosts]);
-    } catch (err) {
-      console.error("검색 실패:", err);
-      setError("검색 결과를 불러오지 못했습니다.");
-      setAllPosts([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [keyword, appliedFilters, sortOption]);
-
-  useEffect(() => {
-    handleSearch();
-  }, [keyword, handleSearch]);
-
-  const totalPages = Math.ceil(allPosts.length / ITEMS_PER_PAGE);
-  const pageItems = allPosts.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
-
-  const handleSortChange = (value: string) => {
-    setSortOption(value);
-    setCurrentPage(1);
-  };
-
-  const handleFilterApply = (filters: FilterOptions) => {
-    setAppliedFilters(filters);
-    setCurrentPage(1);
-  };
-
-  const handleFilterReset = () => {
-    setAppliedFilters({});
-    setCurrentPage(1);
-  };
-
-  const handlePostClick = (post: PostData) => {
-    router.push(`/jobs/${post.id}`);
-  };
+  const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
 
   return (
     <div className="min-h-screen bg-gray-5">
@@ -107,18 +45,17 @@ const SearchPage = () => {
           sortOption={sortOption}
           isFilterOpen={isFilterOpen}
           onSortChange={handleSortChange}
-          onFilterClick={() => setIsFilterOpen(true)}
-          onFilterClose={() => setIsFilterOpen(false)}
+          onFilterClick={handleFilterClick}
+          onFilterClose={handleFilterClose}
           onFilterApply={handleFilterApply}
           onFilterReset={handleFilterReset}
           appliedFilters={appliedFilters}
           title={
             <>
-              <span className="text-primary-10 font-bold">"{keyword}"</span> 검색 결과
+              <span className="text-primary-20 font-bold">"{keyword}"</span> 검색 결과
             </>
           }
-          subtitle=""
-          resultCount={allPosts.length}
+          resultCount={totalItems}
         />
 
         <PostsGrid
@@ -128,8 +65,8 @@ const SearchPage = () => {
           currentPage={currentPage}
           totalPages={totalPages}
           onPostClick={handlePostClick}
-          onPageChange={setCurrentPage}
-          onRetry={handleSearch}
+          onPageChange={handlePageChange}
+          onRetry={() => fetchPosts(currentPage, appliedFilters, sortOption)}
         />
       </div>
     </div>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import PostsHeader from "@/components/jobs/PostsHeader";
+import PostsGrid from "@/components/jobs/PostsGrid";
+import { getNotices } from "@/api/notice/NoticeApi";
+import { PostData } from "@/types/post";
+import { parsePostsResponse } from "@/utils/api";
+import { isPostClosed } from "@/utils/post";
+import { FilterOptions, convertFilterOptionsToApiParams } from "@/types/filter";
+
+const ITEMS_PER_PAGE = 9;
+
+const SearchPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const keyword = searchParams.get("keyword") ?? "";
+  const [allPosts, setAllPosts] = useState<PostData[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [sortOption, setSortOption] = useState("time");
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [appliedFilters, setAppliedFilters] = useState<FilterOptions>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 검색 실행 함수
+  const handleSearch = useCallback(async () => {
+    if (!keyword.trim()) {
+      setAllPosts([]);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setCurrentPage(1);
+
+    try {
+      const apiParams = convertFilterOptionsToApiParams(appliedFilters);
+
+      const response = await getNotices({
+        offset: 0,
+        limit: 100,
+        keyword,
+        address: apiParams.address,
+        startsAtGte: apiParams.startsAtGte,
+        hourlyPayGte: apiParams.hourlyPayGte,
+        sort: sortOption as "time" | "pay" | "hour" | "shop",
+      });
+
+      // API 응답 파싱
+      const parsedPosts = parsePostsResponse(response.items || response);
+
+      const { activePosts, closedPosts } = parsedPosts.reduce(
+        (acc, post) => {
+          if (isPostClosed(post)) {
+            acc.closedPosts.push(post);
+          } else {
+            acc.activePosts.push(post);
+          }
+          return acc;
+        },
+        { activePosts: [] as PostData[], closedPosts: [] as PostData[] },
+      );
+
+      setAllPosts([...activePosts, ...closedPosts]);
+    } catch (err) {
+      console.error("검색 실패:", err);
+      setError("검색 결과를 불러오지 못했습니다.");
+      setAllPosts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [keyword, appliedFilters, sortOption]);
+
+  useEffect(() => {
+    handleSearch();
+  }, [keyword, handleSearch]);
+
+  const totalPages = Math.ceil(allPosts.length / ITEMS_PER_PAGE);
+  const pageItems = allPosts.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
+
+  const handleSortChange = (value: string) => {
+    setSortOption(value);
+    setCurrentPage(1);
+  };
+
+  const handleFilterApply = (filters: FilterOptions) => {
+    setAppliedFilters(filters);
+    setCurrentPage(1);
+  };
+
+  const handleFilterReset = () => {
+    setAppliedFilters({});
+    setCurrentPage(1);
+  };
+
+  const handlePostClick = (post: PostData) => {
+    router.push(`/jobs/${post.id}`);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-5">
+      <div className="max-w-[994px] mx-auto px-4 py-8">
+        <PostsHeader
+          sortOption={sortOption}
+          isFilterOpen={isFilterOpen}
+          onSortChange={handleSortChange}
+          onFilterClick={() => setIsFilterOpen(true)}
+          onFilterClose={() => setIsFilterOpen(false)}
+          onFilterApply={handleFilterApply}
+          onFilterReset={handleFilterReset}
+          appliedFilters={appliedFilters}
+          title={
+            <>
+              <span className="text-primary-10 font-bold">"{keyword}"</span> 검색 결과
+            </>
+          }
+          subtitle=""
+          resultCount={allPosts.length}
+        />
+
+        <PostsGrid
+          posts={pageItems}
+          loading={loading}
+          error={error}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPostClick={handlePostClick}
+          onPageChange={setCurrentPage}
+          onRetry={handleSearch}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SearchPage;

--- a/src/components/common/gnb/Search.tsx
+++ b/src/components/common/gnb/Search.tsx
@@ -1,13 +1,34 @@
+"use client";
+
 import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 const Search = () => {
+  const router = useRouter();
+  const [keyword, setKeyword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const trimmedKeyword = keyword.trim();
+    if (!trimmedKeyword) {
+      return;
+    }
+
+    // 검색 페이지로 이동
+    router.push(`/search?keyword=${encodeURIComponent(trimmedKeyword)}`);
+  };
+
   return (
-    <form className="desktop:w-[450px] tablet:w-[344px] relative flex items-center">
-      <Image className="absolute ml-2.5 mobile:" src="/search.svg" width={20} height={20} alt="검색 아이콘" />
+    <form className="desktop:w-[450px] tablet:w-[344px] relative flex items-center" onSubmit={handleSubmit}>
+      <Image className="absolute ml-2.5" src="/search.svg" width={20} height={20} alt="검색 아이콘" />
       <input
-        className="desktop:w-[450px] tablet:w-[344px] mobile:w-full h-[40px] mobile:h-[36px] bg-gray-10 py-2.5 pl-10 rounded-[10px] placeholder:text-body-1-regular text-body-1-regular mobile:placeholder:text-caption mobile:text-caption placeholder:text-gray-40"
+        className="desktop:w-[450px] tablet:w-[344px] mobile:w-full h-[40px] mobile:h-[36px] bg-gray-10 py-2.5 pl-10 rounded-[10px] placeholder:text-body-1-regular text-body-1-regular mobile:placeholder:text-caption mobile:text-caption placeholder:text-gray-40 focus:outline-none focus:ring-2 focus:ring-primary-20"
         name="keyword"
         type="text"
+        value={keyword}
+        onChange={e => setKeyword(e.target.value)}
         placeholder="가게 이름으로 찾아보세요"
       />
     </form>

--- a/src/components/jobs/PostsHeader.tsx
+++ b/src/components/jobs/PostsHeader.tsx
@@ -1,4 +1,3 @@
-// @/components/jobs/PostsHeader.tsx
 import React from "react";
 import { FilterOptions } from "@/types/filter";
 import CustomDropdown from "@/components/common/input/Dropdown";

--- a/src/components/jobs/PostsHeader.tsx
+++ b/src/components/jobs/PostsHeader.tsx
@@ -1,3 +1,4 @@
+// @/components/jobs/PostsHeader.tsx
 import React from "react";
 import { FilterOptions } from "@/types/filter";
 import CustomDropdown from "@/components/common/input/Dropdown";
@@ -14,6 +15,9 @@ interface PostsHeaderProps {
   onFilterApply: (filters: FilterOptions) => void;
   onFilterReset: () => void;
   appliedFilters: FilterOptions;
+  title?: string | React.ReactNode;
+  subtitle?: string;
+  resultCount?: number;
 }
 
 const PostsHeader = React.memo<PostsHeaderProps>(
@@ -26,41 +30,57 @@ const PostsHeader = React.memo<PostsHeaderProps>(
     onFilterApply,
     onFilterReset,
     appliedFilters,
+    title = "전체 공고",
+    subtitle,
+    resultCount,
   }) => (
-    <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-6 mb-8">
-      <h1 className="text-h1 font-bold text-black">전체 공고</h1>
-
-      <div className="flex items-center gap-2">
-        <div className="w-[130px]">
-          <CustomDropdown
-            name="sort"
-            value={sortOption}
-            options={SORT_OPTIONS}
-            onChange={onSortChange}
-            buttonClassName="h-[37px]"
-          />
+    <>
+      <div className="flex flex-wrap justify-between">
+        {/* 제목 섹션 */}
+        <div className="mb-8">
+          <h1 className="text-h1 font-bold text-black">{title}</h1>
+          {(subtitle !== undefined || resultCount !== undefined) && (
+            <p className="text-body-2-regular text-gray-50 pt-2">
+              {resultCount !== undefined ? `총 ${resultCount}개의 공고를 찾았습니다.` : subtitle}
+            </p>
+          )}
         </div>
 
-        <div className="relative z-10">
-          <Button
-            variant={isFilterOpen ? "primary" : "outlined"}
-            size="small"
-            onClick={onFilterClick}
-            className="whitespace-nowrap px-6"
-          >
-            상세 필터
-          </Button>
+        {/* 정렬 및 필터 섹션 */}
+        <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-6 mb-8">
+          <div className="flex items-center gap-2">
+            <div className="w-[130px]">
+              <CustomDropdown
+                name="sort"
+                value={sortOption}
+                options={SORT_OPTIONS}
+                onChange={onSortChange}
+                buttonClassName="h-[37px]"
+              />
+            </div>
 
-          <DetailFilter
-            isOpen={isFilterOpen}
-            onClose={onFilterClose}
-            onApply={onFilterApply}
-            onReset={onFilterReset}
-            initialFilters={appliedFilters}
-          />
+            <div className="relative z-10">
+              <Button
+                variant={isFilterOpen ? "primary" : "outlined"}
+                size="small"
+                onClick={onFilterClick}
+                className="whitespace-nowrap px-6"
+              >
+                상세 필터
+              </Button>
+
+              <DetailFilter
+                isOpen={isFilterOpen}
+                onClose={onFilterClose}
+                onApply={onFilterApply}
+                onReset={onFilterReset}
+                initialFilters={appliedFilters}
+              />
+            </div>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   ),
 );
 

--- a/src/hooks/useJobPosts.ts
+++ b/src/hooks/useJobPosts.ts
@@ -16,7 +16,14 @@ import { SORT_OPTIONS } from "@/constants/options";
 const ITEMS_PER_PAGE = 9;
 const RECOMMENDED_POSTS_LIMIT = 3;
 
-export const useJobPosts = () => {
+interface UseJobPostsOptions {
+  keyword?: string;
+  isSearchPage?: boolean;
+}
+
+export const useJobPosts = (options: UseJobPostsOptions = {}) => {
+  const { keyword = "", isSearchPage = false } = options;
+
   const [sortOption, setSortOption] = useState<SortOption>(SORT_OPTIONS[0].value as SortOption);
   const [currentPage, setCurrentPage] = useState(1);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
@@ -50,7 +57,10 @@ export const useJobPosts = () => {
     return allPosts.filter((post: PostData) => !isPostClosed(post));
   }, []);
 
+  // 추천 공고 (검색 페이지에서는 스킵)
   const fetchRecommendedPosts = useCallback(async () => {
+    if (isSearchPage) return; // 검색 페이지에서는 실행 안 함
+
     if (!user) {
       setUserLoggedIn(false);
       setRecommendedPosts([]);
@@ -100,60 +110,75 @@ export const useJobPosts = () => {
     } finally {
       setRecLoading(false);
     }
-  }, [user, getUserRegion, getActivePosts]);
+  }, [user, getUserRegion, getActivePosts, isSearchPage]);
 
-  const fetchPosts = useCallback(async (page = 1, filters: FilterOptions = {}, sort: SortOption = "time") => {
-    setLoading(true);
-    setError(null);
+  // 공고 목록 조회 (keyword 파라미터 추가)
+  const fetchPosts = useCallback(
+    async (page = 1, filters: FilterOptions = {}, sort: SortOption = "time") => {
+      setLoading(true);
+      setError(null);
 
-    try {
-      const apiParams = convertFilterOptionsToApiParams(filters);
+      try {
+        const apiParams = convertFilterOptionsToApiParams(filters);
 
-      const responseData = await getNotices({
-        offset: 0,
-        limit: 100,
-        address: apiParams.address,
-        startsAtGte: apiParams.startsAtGte,
-        hourlyPayGte: apiParams.hourlyPayGte,
-        sort,
-      });
+        const responseData = await getNotices({
+          offset: 0,
+          limit: 100,
+          keyword: keyword || undefined, // 검색 페이지에서만 사용
+          address: apiParams.address,
+          startsAtGte: apiParams.startsAtGte,
+          hourlyPayGte: apiParams.hourlyPayGte,
+          sort,
+        });
 
-      const allPosts = parsePostsResponse(responseData);
+        const allPosts = parsePostsResponse(responseData);
 
-      // 한 번의 순회로 active/closed 분류
-      const { activePosts, closedPosts } = allPosts.reduce(
-        (acc, post) => {
-          if (isPostClosed(post)) {
-            acc.closedPosts.push(post);
-          } else {
-            acc.activePosts.push(post);
-          }
-          return acc;
-        },
-        { activePosts: [] as PostData[], closedPosts: [] as PostData[] },
-      );
+        // 한 번의 순회로 active/closed 분류
+        const { activePosts, closedPosts } = allPosts.reduce(
+          (acc, post) => {
+            if (isPostClosed(post)) {
+              acc.closedPosts.push(post);
+            } else {
+              acc.activePosts.push(post);
+            }
+            return acc;
+          },
+          { activePosts: [] as PostData[], closedPosts: [] as PostData[] },
+        );
 
-      const sortedAllPosts = [...activePosts, ...closedPosts];
-      const pageItems = sortedAllPosts.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE);
+        const sortedAllPosts = [...activePosts, ...closedPosts];
+        const pageItems = sortedAllPosts.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE);
 
-      setPosts(pageItems);
-      setTotalItems(responseData?.count || sortedAllPosts.length);
-    } catch (err) {
-      console.error("공고 조회 실패:", err);
-      setError("공고를 불러오는데 실패했습니다.");
-      setPosts([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+        setPosts(pageItems);
+        setTotalItems(responseData?.count || sortedAllPosts.length);
+      } catch (err) {
+        console.error("공고 조회 실패:", err);
+        setError("공고를 불러오는데 실패했습니다.");
+        setPosts([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [keyword],
+  );
 
+  // 추천 공고 조회
   useEffect(() => {
     fetchRecommendedPosts();
   }, [user, fetchRecommendedPosts]);
 
+  // 일반 공고 조회 (keyword, 필터, 정렬 변경 시)
   useEffect(() => {
-    fetchPosts(currentPage, appliedFilters, sortOption);
-  }, [currentPage, appliedFilters, sortOption, fetchPosts]);
+    setCurrentPage(1); // keyword 변경 시 첫 페이지로 리셋
+    fetchPosts(1, appliedFilters, sortOption);
+  }, [keyword, appliedFilters, sortOption, fetchPosts]);
+
+  // 페이지만 변경될 때
+  useEffect(() => {
+    if (currentPage !== 1) {
+      fetchPosts(currentPage, appliedFilters, sortOption);
+    }
+  }, [currentPage, fetchPosts, appliedFilters, sortOption]);
 
   const handleSortChange = useCallback((value: string) => {
     setSortOption(value as SortOption);

--- a/src/hooks/useJobPosts.ts
+++ b/src/hooks/useJobPosts.ts
@@ -169,9 +169,8 @@ export const useJobPosts = (options: UseJobPostsOptions = {}) => {
 
   // 일반 공고 조회 (keyword, 필터, 정렬 변경 시)
   useEffect(() => {
-    setCurrentPage(1); // keyword 변경 시 첫 페이지로 리셋
-    fetchPosts(1, appliedFilters, sortOption);
-  }, [keyword, appliedFilters, sortOption, fetchPosts]);
+    fetchPosts(currentPage, appliedFilters, sortOption);
+  }, [currentPage, keyword, appliedFilters, sortOption, fetchPosts]);
 
   // 페이지만 변경될 때
   useEffect(() => {


### PR DESCRIPTION
## 검색 페이지 구현

### 추가
- @/app/search/page.tsx
- gnb의 Search 컴포넌트 검색 로직 구현

### 수정
- 전체 공고에 사용하는 @/hooks/useJobPosts.ts 훅 공용으로 수정 (검색 페이지에서도 사용)
- 마찬가지로 전체 공고에 사용하는 @/components/jobs/PostsHeader.tsx 의 title 부분 검색 페이지에서도 사용할 수 있게 수정

### 이미지
<img width="1246" height="1451" alt="screencapture-localhost-3000-search-2025-10-20-16_55_31" src="https://github.com/user-attachments/assets/7e7087a8-d681-49a8-bb40-ffcf4c0be226" />
