### PR TITLE
[추가] 가게 등록 페이지 구현

### DIFF
--- a/src/api/image/ImageApi.ts
+++ b/src/api/image/ImageApi.ts
@@ -1,0 +1,100 @@
+import instance from "@/api/axios";
+import { handleApiError } from "@/api/error/ErrorHandler";
+
+interface PresignedUrlResponse {
+  item: {
+    url: string; // Presigned URL (query parameters 포함)
+  };
+  links: unknown[];
+}
+
+// 이미지 업로드 결과 타입
+export interface ImageUploadResult {
+  url: string; // 최종 이미지 URL (query parameters 제외)
+}
+
+/**
+ * Presigned URL 생성
+ * POST /images
+ *
+ * @param fileName - 업로드할 파일 이름
+ * @returns Presigned URL
+ */
+export const createPresignedUrl = async (fileName: string): Promise<string> => {
+  try {
+    const response = await instance.post<PresignedUrlResponse>("/images", {
+      name: fileName,
+    });
+
+    return response.data.item.url;
+  } catch (error) {
+    return handleApiError(error);
+  }
+};
+
+/**
+ * S3에 이미지 업로드
+ * PUT Presigned URL (query parameters 포함)
+ *
+ * @param presignedUrl - Presigned URL
+ * @param file - 업로드할 파일
+ */
+export const uploadToS3 = async (presignedUrl: string, file: File): Promise<void> => {
+  try {
+    const response = await fetch(presignedUrl, {
+      method: "PUT",
+      body: file,
+      headers: {
+        "Content-Type": file.type,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`S3 업로드 실패: ${response.statusText}`);
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error("S3 업로드 중 오류가 발생했습니다.");
+  }
+};
+
+/**
+ * Query parameters 제거
+ *
+ * @param presignedUrl - Presigned URL (query parameters 포함)
+ * @returns 최종 이미지 URL (query parameters 제외)
+ */
+export const removeQueryParameters = (presignedUrl: string): string => {
+  return presignedUrl.split("?")[0];
+};
+
+/**
+ * 전체 이미지 업로드 프로세스
+ * 1. Presigned URL 생성
+ * 2. S3에 업로드
+ * 3. Query parameters 제거한 URL 반환
+ *
+ * @param file - 업로드할 이미지 파일
+ * @returns 최종 이미지 URL (query parameters 제외)
+ */
+export const uploadImage = async (file: File): Promise<string> => {
+  try {
+    // Presigned URL 생성
+    const presignedUrl = await createPresignedUrl(file.name);
+
+    // S3에 업로드
+    await uploadToS3(presignedUrl, file);
+
+    // Query parameters 제거
+    const imageUrl = removeQueryParameters(presignedUrl);
+
+    return imageUrl;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error("이미지 업로드에 실패했습니다.");
+  }
+};

--- a/src/app/(dashboard)/owner/register-shop/page.tsx
+++ b/src/app/(dashboard)/owner/register-shop/page.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Image from "next/image";
+import Button from "@/components/common/button";
+import Input from "@/components/common/input/Input";
+import { ShopImageUpload } from "@/components/owner/shop/shopImageUpload";
+import { useShopForm } from "@/hooks/useShopForm";
+import { getShop } from "@/api/shop/ShopApi";
+import { ShopItem } from "@/types/shop";
+import { CATEGORY_OPTIONS, REGION_OPTIONS } from "@/constants/options";
+
+export default function NoticeRegisterPage() {
+  const searchParams = useSearchParams();
+
+  // 쿼리 파라미터에서 mode 확인
+  const mode = searchParams.get("mode") === "edit" ? "edit" : "new";
+  const shopIdFromQuery = searchParams.get("shopId");
+
+  const [shopData, setShopData] = useState<ShopItem | null>(null);
+  const [isLoadingShop, setIsLoadinngShop] = useState(false);
+  const [shopError, setShopError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (mode === "edit" && shopIdFromQuery) {
+      setIsLoadinngShop(true);
+      getShop(shopIdFromQuery)
+        .then(response => {
+          setShopData(response.item);
+        })
+        .catch(err => {
+          setShopError(err.message || "가게 정보를 불러오는데 실패했습니다.");
+        })
+        .finally(() => {
+          setIsLoadinngShop(false);
+        });
+    }
+  }, [mode, shopIdFromQuery]);
+
+  // 폼 로직
+  const {
+    formData,
+    validationErrors,
+    isLoading,
+    error,
+    handleInputChange,
+    handleInputBlur,
+    handleImageUpload,
+    handleSubmit,
+    handleClose,
+  } = useShopForm({
+    mode,
+    shopId: shopIdFromQuery,
+    initialData: mode === "edit" ? shopData : null,
+  });
+
+  // 편집 모드에서 가게 정보 로딩 중
+  if (mode === "edit" && isLoadingShop) {
+    return (
+      <main className="w-full max-w-[680px] mx-auto my-[3.75rem] px-8 flex items-center justify-center">
+        <p className="text-body-1-regular text-gray-40">가게 정보를 불러오는 중...</p>
+      </main>
+    );
+  }
+
+  // 편집 모드에서 가게 정보 로딩 실패
+  if (mode === "edit" && (shopError || !shopData)) {
+    return (
+      <main className="w-full max-w-[680px] mx-auto my-[3.75rem] px-8">
+        <div className="w-full mb-4 p-4 bg-red-10 border border-red-40 rounded-lg text-red-40">
+          {shopError || "가게 정보를 찾을 수 없습니다."}
+        </div>
+        <Button onClick={handleClose} variant="primary">
+          돌아가기
+        </Button>
+      </main>
+    );
+  }
+
+  return (
+    <main className="w-full max-w-[968px] mx-auto my-6 tablet:my-[3.75rem] px-4 tablet:px-8">
+      {/* 헤더 */}
+      <div className="flex justify-between items-center mb-4 tablet:mb-6">
+        <h1 className="text-h2 tablet:text-h1">가게 정보</h1>
+        <button type="button" onClick={handleClose} aria-label="닫기">
+          <Image src="/close.svg" width={32} height={32} alt="닫기 아이콘" />
+        </button>
+      </div>
+
+      {/* 폼 */}
+      <form onSubmit={handleSubmit} className="w-full">
+        <div className="flex flex-col gap-4 tablet:gap-5">
+          {/* 가게 이름 */}
+          <Input
+            name="name"
+            type="text"
+            label="가게 이름"
+            placeholder="입력"
+            value={formData.name}
+            onChange={handleInputChange}
+            onBlur={handleInputBlur}
+            error={validationErrors.name}
+            required
+          />
+
+          {/* 분류와 주소 (반응형 1열 → 2열) */}
+          <div className="grid grid-cols-1 tablet:grid-cols-2 gap-4 tablet:gap-5">
+            {/* 분류 */}
+            <div className="flex flex-col gap-1">
+              <label htmlFor="category" className="text-body-2-regular text-gray-50">
+                분류 <span className="text-red-40 ml-0.5">*</span>
+              </label>
+              <select
+                id="category"
+                name="category"
+                value={formData.category}
+                onChange={handleInputChange}
+                onBlur={handleInputBlur}
+                className={`w-full h-[58px] rounded-lg px-3 text-body-1-regular bg-white border focus:outline-none focus:ring-2
+                  ${
+                    validationErrors.category
+                      ? "border-red-40 bg-red-10 focus:ring-red-30"
+                      : "border-gray-30 focus:ring-blue-20"
+                  }
+                `}
+              >
+                <option value="">선택</option>
+                {CATEGORY_OPTIONS.map(option => (
+                  <option key={option.value} value={option.label}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              {validationErrors.category && <p className="text-caption text-red-40">{validationErrors.category}</p>}
+            </div>
+
+            {/* 주소 */}
+            <div className="flex flex-col gap-1">
+              <label htmlFor="address1" className="text-body-2-regular text-gray-50">
+                주소 <span className="text-red-40 ml-0.5">*</span>
+              </label>
+              <select
+                id="address1"
+                name="address1"
+                value={formData.address1}
+                onChange={handleInputChange}
+                onBlur={handleInputBlur}
+                className={`w-full h-[58px] rounded-lg px-3 text-body-1-regular bg-white border focus:outline-none focus:ring-2
+                  ${
+                    validationErrors.address1
+                      ? "border-red-40 bg-red-10 focus:ring-red-30"
+                      : "border-gray-30 focus:ring-blue-20"
+                  }
+                `}
+              >
+                <option value="">선택</option>
+                {REGION_OPTIONS.map(option => (
+                  <option key={option.value} value={option.label}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              {validationErrors.address1 && <p className="text-caption text-red-40">{validationErrors.address1}</p>}
+            </div>
+          </div>
+
+          {/* 상세 주소 */}
+          <Input
+            name="address2"
+            type="text"
+            label="상세 주소"
+            placeholder="입력"
+            value={formData.address2}
+            onChange={handleInputChange}
+            onBlur={handleInputBlur}
+            error={validationErrors.address2}
+            required
+          />
+
+          {/* 기본 시급 */}
+          <Input
+            name="originalHourlyPay"
+            type="number"
+            label="기본 시급"
+            unit="원"
+            placeholder="입력"
+            value={formData.originalHourlyPay}
+            onChange={handleInputChange}
+            onBlur={handleInputBlur}
+            error={validationErrors.originalHourlyPay}
+            required
+          />
+
+          {/* 가게 이미지 */}
+          <ShopImageUpload
+            imageUrl={formData.imageUrl}
+            onImageUpload={handleImageUpload}
+            error={validationErrors.imageUrl}
+          />
+
+          {/* 가게 설명 */}
+          <div className="flex flex-col gap-1">
+            <label htmlFor="description" className="text-body-2-regular text-gray-50">
+              가게 설명
+            </label>
+            <textarea
+              id="description"
+              name="description"
+              placeholder="입력"
+              value={formData.description}
+              onChange={handleInputChange}
+              className="w-full h-[153px] rounded-lg p-4 text-body-1-regular bg-white border border-gray-30 focus:outline-none focus:ring-2 focus:ring-blue-20 resize-none"
+            />
+          </div>
+
+          {/* 에러 메시지 */}
+          {error && (
+            <div className="p-4 bg-red-10 border border-red-40 rounded-lg">
+              <p className="text-body-2-regular text-red-40">{error}</p>
+            </div>
+          )}
+
+          {/* 제출 버튼 */}
+          <Button variant="primary" size="large" type="submit" disabled={isLoading}>
+            {isLoading ? (mode === "edit" ? "수정 중..." : "등록 중...") : mode === "edit" ? "수정하기" : "등록하기"}
+          </Button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/components/owner/ShopInfo.tsx
+++ b/src/components/owner/ShopInfo.tsx
@@ -47,7 +47,7 @@ export const ShopInfo = ({ shop }: ShopInfoProps) => {
             {/* 버튼 */}
             <div className="w-full flex gap-2">
               <div className="w-full">
-                <Link href={`/owner/edit-shop/${shop.id}`}>
+                <Link href={`/owner/register-shop?mode=edit&shopId=${shop.id}`}>
                   <Button variant="outlined" className=" w-full" size="large">
                     편집하기
                   </Button>

--- a/src/components/owner/shop/shopImageUpload.tsx
+++ b/src/components/owner/shop/shopImageUpload.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { ChangeEvent, useRef, useState } from "react";
+import Image from "next/image";
+import { uploadImage } from "@/api/image/ImageApi";
+
+interface ImageUploadProps {
+  imageUrl: string;
+  onImageUpload: (url: string) => void;
+  error?: string;
+}
+
+/**
+ * 이미지 업로드 컴포넌트
+ * - 이미지 선택 및 미리보기
+ * - 서버에 이미지 업로드 (Presigned URL 사용)
+ */
+export const ShopImageUpload = ({ imageUrl, onImageUpload, error }: ImageUploadProps) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  /**
+   * 이미지 선택 영역 클릭 핸들러
+   */
+  const handleClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  /**
+   * 파일 선택 핸들러
+   */
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // 파일 타입 검증
+    if (!file.type.startsWith("image/")) {
+      setUploadError("이미지 파일만 업로드 가능합니다.");
+      return;
+    }
+
+    // 파일 크기 검증 (5MB)
+    if (file.size > 5 * 1024 * 1024) {
+      setUploadError("파일 크기는 5MB 이하여야 합니다.");
+      return;
+    }
+
+    setIsUploading(true);
+    setUploadError(null);
+
+    try {
+      // 이미지 업로드 (Presigned URL 사용)
+      const uploadedImageUrl = await uploadImage(file);
+
+      // 업로드된 이미지 URL 전달
+      onImageUpload(uploadedImageUrl);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "이미지 업로드에 실패했습니다.";
+      setUploadError(errorMessage);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <div>
+      <label className="block text-body-2-regular text-gray-50 mb-2">
+        가게 이미지 <span className="text-primary-20">*</span>
+      </label>
+
+      <div
+        onClick={handleClick}
+        className={`relative w-full h-[276px] border-2 border-dashed rounded-lg cursor-pointer transition-colors overflow-hidden
+            ${error || uploadError ? "border-red-40 bg-red-10" : "border-gray-30 hover:border-gray-40 bg-gray-10"}
+            `}
+      >
+        {/* 이미지 미리보기 */}
+        {imageUrl ? (
+          <div className="relative w-full h-full">
+            <Image src={imageUrl} alt="가게 이미지 미리보기" fill className="object-cover" />
+            <div className="absolute inset-0 bg-black bg-opacity-0 hover:bg-opacity-20 transition-all flex items-center justify-center">
+              <span className="opacity-0 hover:opacity-100 text-white text-body-1-bold">이미지 변경하기</span>
+            </div>
+          </div>
+        ) : (
+          /* 업로드 안내 */
+          <div className="flex flex-col items-center justify-center h-full">
+            <p className="text-body-1-regular text-gray-40">
+              {isUploading ? "이미지 업로드 중..." : "이미지 추가하기"}
+            </p>
+          </div>
+        )}
+
+        {/* Hidden File Input */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          className="hidden"
+          disabled={isUploading}
+        />
+      </div>
+
+      {/* 에러 메시지 */}
+      {(error || uploadError) && <p className="mt-2 text-caption text-red-40">{error || uploadError}</p>}
+    </div>
+  );
+};

--- a/src/hooks/useNoticeForm.ts
+++ b/src/hooks/useNoticeForm.ts
@@ -195,7 +195,7 @@ export const useNoticeForm = ({
       } else {
         // 등록 모드: POST 요청
         await postShopNotice(shopId, requestBody);
-        router.push(`/shops/notice/${shopId}/${noticeId}`);
+        router.push("/owner");
       }
     } catch (err) {
       const message =

--- a/src/hooks/useShopForm.ts
+++ b/src/hooks/useShopForm.ts
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState, useEffect, ChangeEvent, FocusEvent, FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { putShop, postShop } from "@/api/shop/ShopApi";
+import {
+  ShopFormData,
+  ShopValidationErrors,
+  createEmptyErrors,
+  validateShopForm,
+  validateShopName,
+  validateCategory,
+  validateAddress1,
+  validateAddress2,
+  validateOriginalHourlyPay,
+  validateImageUrl,
+  hasValidationErrors,
+} from "@/utils/shopValidation";
+import { ShopItem } from "@/types/shop";
+
+type FormMode = "new" | "edit";
+
+interface UseShopFormProps {
+  mode?: FormMode;
+  shopId?: string | null;
+  initialData?: ShopItem | null;
+}
+
+interface UseShopFormReturn {
+  mode: FormMode;
+  formData: ShopFormData;
+  validationErrors: ShopValidationErrors;
+  isLoading: boolean;
+  error: string | null;
+  handleInputChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
+  handleInputBlur: (e: FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
+  handleImageUpload: (imageUrl: string) => void;
+  handleSubmit: (e: FormEvent<HTMLFormElement>) => Promise<void>;
+  handleClose: () => void;
+}
+
+// 필드별 유효성 검사 함수 매핑
+const FIELD_VALIDATORS: Record<string, (value: string) => string> = {
+  name: validateShopName,
+  category: validateCategory,
+  address1: validateAddress1,
+  address2: validateAddress2,
+  originalHourlyPay: validateOriginalHourlyPay,
+  imageUrl: validateImageUrl,
+};
+
+export const useShopForm = ({ mode = "new", shopId, initialData }: UseShopFormProps): UseShopFormReturn => {
+  const router = useRouter();
+
+  const initialFormData = <ShopFormData>{
+    name: "",
+    category: "",
+    address1: "",
+    address2: "",
+    originalHourlyPay: "",
+    imageUrl: "",
+    description: "",
+  };
+
+  const [formData, setFormData] = useState<ShopFormData>(initialFormData);
+  const [validationErrors, setValidationErrors] = useState<ShopValidationErrors>(createEmptyErrors());
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  //   편집모드 초기 데이터로 폼 채우기
+  useEffect(() => {
+    if (mode === "edit" && initialData) {
+      setFormData({
+        name: initialData.name,
+        category: initialData.category,
+        address1: initialData.address1,
+        address2: initialData.address2,
+        originalHourlyPay: String(initialData.originalHourlyPay),
+        imageUrl: initialData.imageUrl,
+        description: initialData.description,
+      });
+    }
+  }, [mode, initialData]);
+
+  //   입력값 변경 핸들러
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+
+    setFormData(prev => ({
+      ...prev,
+      [name]: value,
+    }));
+
+    // 입력 시 해당 필드의 에러 초기화
+    setValidationErrors(prev => ({
+      ...prev,
+      [name]: "",
+    }));
+  };
+
+  //   입력 필드 Blur 시 개별 유효성 검사
+  const handleInputBlur = (e: FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+
+    // 해당 필드의 validator 함수 가져오기
+    const validator = FIELD_VALIDATORS[name];
+
+    if (validator) {
+      const errorMessage = validator(value);
+      setValidationErrors(prev => ({
+        ...prev,
+        [name]: errorMessage,
+      }));
+    }
+  };
+
+  // 이미지 업로드
+  const handleImageUpload = (imageUrl: string) => {
+    setFormData(prev => ({
+      ...prev,
+      imageUrl,
+    }));
+
+    setValidationErrors(prev => ({
+      ...prev,
+      imageUrl: "",
+    }));
+  };
+
+  // API 요청 데이터 생성
+  const createRequestBody = () => {
+    return {
+      name: formData.name.trim(),
+      category: formData.category,
+      address1: formData.address1,
+      address2: formData.address2.trim(),
+      originalHourlyPay: Number(formData.originalHourlyPay),
+      imageUrl: formData.imageUrl,
+      description: formData.description.trim() || "", // 빈 문자열도 허용
+    };
+  };
+
+  // 폼 제출 핸들러 (등록 또는 수정)
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    // 전체 유효성 검사
+    const errors = validateShopForm(formData);
+    setValidationErrors(errors);
+
+    if (hasValidationErrors(errors)) {
+      setError("입력 내용을 확인해주세요.");
+      return;
+    }
+
+    // 편집 모드일 때 shopId 확인
+    if (mode === "edit" && !shopId) {
+      setError("가게 정보가 없습니다.");
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const requestBody = createRequestBody();
+
+      if (mode === "edit" && shopId) {
+        // 편집 모드: PUT 요청
+        await putShop(shopId, requestBody);
+      } else {
+        // 등록 모드: POST 요청
+        await postShop(requestBody);
+      }
+
+      // 성공 시 사장 페이지로 이동
+      router.push("/owner");
+      router.refresh();
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : mode === "edit"
+          ? "가게 수정에 실패했습니다."
+          : "가게 등록에 실패했습니다.";
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    router.back();
+  };
+
+  return {
+    mode,
+    formData,
+    validationErrors,
+    isLoading,
+    error,
+    handleInputChange,
+    handleInputBlur,
+    handleImageUpload,
+    handleSubmit,
+    handleClose,
+  };
+};

--- a/src/utils/shopValidation.ts
+++ b/src/utils/shopValidation.ts
@@ -1,0 +1,147 @@
+import { CATEGORY_OPTIONS, REGION_OPTIONS } from "@/constants/options";
+
+// 가게 폼 데이터 타입
+export interface ShopFormData {
+  name: string;
+  category: string;
+  address1: string;
+  address2: string;
+  originalHourlyPay: string;
+  imageUrl: string;
+  description: string;
+}
+
+// 가게 폼 유효성 에러 타입
+export interface ShopValidationErrors {
+  name: string;
+  category: string;
+  address1: string;
+  address2: string;
+  originalHourlyPay: string;
+  imageUrl: string;
+  description: string;
+}
+
+// 빈 에러 객체 생성
+export const createEmptyErrors = (): ShopValidationErrors => ({
+  name: "",
+  category: "",
+  address1: "",
+  address2: "",
+  originalHourlyPay: "",
+  imageUrl: "",
+  description: "",
+});
+
+// 가게 이름 유효성 검사
+export const validateShopName = (name: string): string => {
+  const trimmedName = name.trim();
+
+  if (!trimmedName) {
+    return "가게 이름을 입력해주세요.";
+  }
+
+  if (trimmedName.length < 2) {
+    return "가게 이름은 2글자 이상이어야 합니다.";
+  }
+
+  if (trimmedName.length > 50) {
+    return "가게 이름은 50글자 이하여야 합니다.";
+  }
+
+  return "";
+};
+
+// 분류 유효성 검사
+export const validateCategory = (category: string): string => {
+  if (!category || !category.trim()) {
+    return "분류를 선택해주세요.";
+  }
+
+  // 허용된 카테고리 목록 확인
+  const validCategories = CATEGORY_OPTIONS.map(opt => opt.label);
+  if (!validCategories.includes(category)) {
+    return "올바른 분류를 선택해주세요.";
+  }
+
+  return "";
+};
+
+// 주소 유효성 검사
+export const validateAddress1 = (address1: string): string => {
+  if (!address1 || !address1.trim()) {
+    return "주소를 선택해주세요.";
+  }
+
+  // 허용된 주소 목록 확인
+  const validAddresses = REGION_OPTIONS.map(opt => opt.label);
+  if (!validAddresses.includes(address1)) {
+    return "올바른 주소를 선택해주세요.";
+  }
+
+  return "";
+};
+
+// 상세 주소 유효성 검사
+export const validateAddress2 = (address2: string): string => {
+  const trimmedAddress = address2.trim();
+
+  if (!trimmedAddress) {
+    return "상세 주소를 입력해주세요.";
+  }
+
+  if (trimmedAddress.length < 2) {
+    return "상세 주소는 2글자 이상이어야 합니다.";
+  }
+
+  return "";
+};
+
+// 기본 시급 유효성 검사
+export const validateOriginalHourlyPay = (pay: string): string => {
+  if (!pay || !pay.trim()) {
+    return "기본 시급을 입력해주세요.";
+  }
+
+  const numPay = Number(pay);
+
+  if (isNaN(numPay)) {
+    return "올바른 숫자를 입력해주세요.";
+  }
+
+  if (numPay < 9860) {
+    return "2024년 최저시급(9,860원) 이상이어야 합니다.";
+  }
+
+  if (numPay > 1000000) {
+    return "시급은 1,000,000원 이하여야 합니다.";
+  }
+
+  return "";
+};
+
+// 이미지 URL 유효성 검사
+export const validateImageUrl = (imageUrl: string): string => {
+  if (!imageUrl || !imageUrl.trim()) {
+    return "가게 이미지를 등록해주세요.";
+  }
+  return "";
+};
+
+// 전체 폼 유효성 검사
+export const validateShopForm = (formData: ShopFormData): ShopValidationErrors => {
+  return {
+    name: validateShopName(formData.name),
+    category: validateCategory(formData.category),
+    address1: validateAddress1(formData.address1),
+    address2: validateAddress2(formData.address2),
+    originalHourlyPay: validateOriginalHourlyPay(formData.originalHourlyPay),
+    imageUrl: validateImageUrl(formData.imageUrl),
+    description: "", // 선택사항
+  };
+};
+
+// 에러가 있는지 확인
+export const hasValidationErrors = (errors: ShopValidationErrors): boolean => {
+  return Object.values(errors).some(error => error !== "");
+};


### PR DESCRIPTION
# 개요

가게 등록 페이지를 구현하였습니다.


# 변경 사항

- 이미지 API 연동
- 폼 유효성 검사
-  편집모드 구현
- 가게 정보 컴포넌트 URL 경로 변경

| 등록 | 편집 |
| --- | --- |
|<img width="3360" height="2578" alt="localhost_3000_owner_register-shop" src="https://github.com/user-attachments/assets/483167c0-89cd-4fc1-b70f-94e6eb2a77e4" />|<img width="3360" height="2578" alt="localhost_3000_owner (3)" src="https://github.com/user-attachments/assets/a9b091a4-6821-4f1a-b31b-3624774e7168" />|




# 추가 작업분(순서)

1. (알바) 공고 상세 페이지 구현
2. 페이지네이션 연결
3. 페이지 먼저 구현 후 반응형을 구현
4. 모달(토스트) 연동