### PR TITLE
[추가] 알바 공고 상세 페이지 구현

### DIFF
--- a/src/app/jobs/[shopId]/[noticeId]/page.tsx
+++ b/src/app/jobs/[shopId]/[noticeId]/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { NoticeInfo } from "@/components/owner/notice/NoticeInfo";
+import { useShopNoticeDetail } from "@/hooks/useShopNoticeDetail";
+import { useAuth } from "@/hooks/useAuth";
+import { useNoticeApplication } from "@/hooks/useNoticeApplication";
+import { PostData } from "@/types/post";
+import { LatestNotice } from "@/components/owner/notice/LatestNotice";
+import { useEffect } from "react";
+
+export default function JobDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const { user } = useAuth();
+
+  const shopId = typeof params.shopId === "string" ? params.shopId : null;
+  const noticeId = typeof params.noticeId === "string" ? params.noticeId : null;
+
+  const { noticeDetail, isLoading, error } = useShopNoticeDetail(shopId, noticeId);
+
+  const {
+    isApplying,
+    applicationError,
+    hasApplied,
+    applicationStatus,
+    applyForNotice,
+  } = useNoticeApplication(noticeDetail);
+
+  useEffect(() => {
+    if(!isLoading && !error && noticeDetail && noticeId && shopId) {
+      
+      // PostCar가 필요로 하는 PostData 형식으로 현재 공고 데이터로 변환
+      const currentNotice: PostData = {
+        id: noticeId,
+        hourlyPay: noticeDetail.hourlyPay,
+        startsAt: noticeDetail.startsAt,
+        workhour: noticeDetail.workhour,
+        closed: noticeDetail.closed,     
+        shop: {
+          id: shopId,
+          name: noticeDetail.shop.item.name,
+          address1: noticeDetail.shop.item.address1,
+          imageUrl: noticeDetail.shop.item.imageUrl,
+          originalHourlyPay: noticeDetail.shop.item.originalHourlyPay
+        }
+      };
+      
+      // localStorage에서 기존 목록 읽기
+      const storage = localStorage.getItem('latest');
+      let latestList: PostData[] = storage ? JSON.parse(storage) : [];
+
+      // 현재 공고가 이미 목록에 있는지 확인하고, 있다면 제거(최신순 유지)
+      latestList = latestList.filter(item => item.id !== currentNotice.id)
+
+      // 현재 공고를 목록 맨 앞에 추가
+      latestList.unshift(currentNotice);
+
+      // 목록을 6개로 제한
+      const limitedList = latestList.slice(0, 7);
+
+      // localStorage에 다시 저장
+      localStorage.setItem('latest', JSON.stringify(limitedList));
+
+      // 현재 탭의 LatestNotice 컴포넌트도 바로 갱신 (수동 이벤트 발생)
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: 'latest',
+        newValue: JSON.stringify(limitedList)
+      }));
+    }
+  }, [isLoading, error, noticeDetail, noticeId, shopId])
+
+  // 로딩 중
+  if (isLoading) {
+    return (
+      <main className="w-full min-h-screen bg-gray-5 flex items-center justify-center">
+        <div className="text-body-1-regular text-gray-40">로딩 중...</div>
+      </main>
+    );
+  }
+
+  // 에러 발생
+  if (error || !noticeDetail) {
+    return (
+      <main className="w-full min-h-screen bg-gray-5 flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-body-1-regular text-red-40 mb-4">
+            {error || "공고를 찾을 수 없습니다."}
+          </p>
+          <button
+            onClick={() => router.back()}
+            className="px-4 py-2 bg-primary-20 text-white rounded hover:bg-primary-30"
+          >
+            돌아가기
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  // 신청하기 핸들러
+  const handleApply = async () => {
+    if (!user) {
+      alert("로그인이 필요합니다.");
+      router.push("/login");
+      return;
+    }
+
+    if (user.type !== "employee") {
+      alert("알바 계정만 신청할 수 있습니다.");
+      return;
+    }
+
+    await applyForNotice();
+  };
+
+  return (
+    <main className="w-full min-h-screen bg-gray-5 flex flex-col items-center">
+      {/* 공고 상세 정보 */}
+      <section className="max-w-[964px] w-full py-[60px]">
+        <div className="mb-6">
+          <span className="text-primary-20 text-body-1-bold mb-2 block">
+            {noticeDetail.shop.item.category}
+          </span>
+          <h1 className="text-h1">{noticeDetail.shop.item.name}</h1>
+        </div>
+        <NoticeInfo
+          noticeDetail={noticeDetail}
+          userRole="employee"
+          onApply={handleApply}
+          hasApplied={hasApplied}
+          applicationStatus={applicationStatus}
+          isApplying={isApplying}
+          applicationError={applicationError}
+        />
+      </section>
+
+             {/* 최근에 본 공고 목록 */}
+             <section className="max-w-[964px] w-full py-[60px]">
+               <h2 className="text-h1 mb-8">최근에 본 공고</h2>
+               <LatestNotice/>
+             </section>
+    </main>
+  );
+}

--- a/src/components/owner/notice/LatestNotice.tsx
+++ b/src/components/owner/notice/LatestNotice.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import PostCard, {PostData} from "@/components/common/post/PostCard";
+
+export const LatestNotice = () => {
+  const [latestArray, setLatestArray] = useState<PostData[] | null>(null);
+  const router = useRouter()
+
+  useEffect(() => {
+    const loadLatest = () => {
+        const storage = localStorage.getItem("latest");
+
+        setLatestArray(storage ? JSON.parse(storage).slice(0, 6) : null)
+    }
+
+    loadLatest()
+
+    const handleStorageChange = (e: StorageEvent) => {
+        if(e.key === "latest") {
+            setLatestArray(e.newValue ? JSON.parse(e.newValue).slice(0, 6) : null)
+        }
+    }
+
+    window.addEventListener("storage", handleStorageChange);
+
+    return () => {
+       window.addEventListener("storage", handleStorageChange); 
+    }
+  }, []);
+
+const handleCardClick = (notice: PostData) => {
+    router.push(`/owner/notice/${notice.shop.id}/${notice.id}`);
+  };
+
+  return (
+    <>
+      {!latestArray || latestArray.length === 0 ? (
+        <div className="flex justify-center">
+          <h3>최근에 본 공고가 없습니다.</h3>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 w-full">
+        {latestArray.map(notice => (
+            <PostCard
+              post={notice}
+              key={notice.id}
+              onClick={() => handleCardClick(notice)}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/components/owner/notice/NoticeInfo.tsx
+++ b/src/components/owner/notice/NoticeInfo.tsx
@@ -3,18 +3,32 @@ import Link from "next/link";
 import Button from "@/components/common/button";
 import { formatDate, formatTime } from "@/utils/date";
 import { NoticeDetailItem } from "@/types/notice";
+import { ApplicationStatus } from "@/types/application";
 
 interface NoticeInfoProps {
   noticeDetail: NoticeDetailItem;
-  onClick?: () => void;
+  userRole?: "employer" | "employee";
+  onApply?: () => void;
+  hasApplied?: boolean;
+  applicationStatus?: ApplicationStatus | null;
+  isApplying?: boolean;
+  applicationError?: string | null;
 }
 
-export const NoticeInfo = ({ noticeDetail, onClick }: NoticeInfoProps) => {
-  const { shop, hourlyPay, startsAt, workhour, description, id } = noticeDetail;
+export const NoticeInfo = ({
+  noticeDetail,
+  userRole = "employer",
+  onApply,
+  hasApplied = false,
+  applicationStatus,
+  isApplying = false,
+  applicationError,
+}: NoticeInfoProps) => {
+  const { shop, hourlyPay, startsAt, workhour, description, id, closed } = noticeDetail;
 
-  // 숫자를 통화 형식으로 포멧팅
-  const formatCurrency = (amoubt: number): string => {
-    return new Intl.NumberFormat("ko-KR").format(amoubt);
+  // 숫자를 통화 형식으로 포맷팅
+  const formatCurrency = (amount: number): string => {
+    return new Intl.NumberFormat("ko-KR").format(amount);
   };
 
   // 날짜 포맷팅
@@ -35,30 +49,90 @@ export const NoticeInfo = ({ noticeDetail, onClick }: NoticeInfoProps) => {
   };
   const increaseRate = calculateIncreaseRate();
 
+  // 신청 상태에 따른 버튼 텍스트 및 스타일
+  const getApplicationButtonProps = () => {
+    if (closed) {
+      return {
+        text: "마감 완료",
+        disabled: true,
+        variant: "outlined" as const,
+      };
+    }
+
+    if (!hasApplied) {
+      return {
+        text: "신청하기",
+        disabled: false,
+        variant: "primary" as const,
+      };
+    }
+
+    switch (applicationStatus) {
+      case "pending":
+        return {
+          text: "신청 완료",
+          disabled: true,
+          variant: "outlined" as const,
+        };
+      case "accepted":
+        return {
+          text: "승인됨",
+          disabled: true,
+          variant: "blue" as const,
+        };
+      case "rejected":
+        return {
+          text: "거절됨",
+          disabled: true,
+          variant: "outlined" as const,
+        };
+      case "canceled":
+        return {
+          text: "취소됨",
+          disabled: true,
+          variant: "outlined" as const,
+        };
+      default:
+        return {
+          text: "신청하기",
+          disabled: false,
+          variant: "primary" as const,
+        };
+    }
+  };
+
+  const buttonProps = getApplicationButtonProps();
+
   return (
     <div className="w-full">
-      <div className=" border border-gray-20 rounded-xl">
-        <div className="flex w-full bg-white p-6 gap-[30px] rounded-xl">
+      <div className="border border-gray-20 rounded-xl">
+        <div className="flex w-full bg-white p-6 gap-[30px] rounded-xl flex-col md:flex-row">
           {/* 가게 이미지 */}
-          <div className="relative w-[539px] h-[309px]">
-            <Image src={shop.item.imageUrl} alt={shop.item.name} fill className="object-cover rounded-xl" priority />
+          <div className="relative w-full md:w-[539px] h-[309px]">
+            <Image
+              src={shop.item.imageUrl}
+              alt={shop.item.name}
+              fill
+              className="object-cover rounded-xl"
+              priority
+            />
           </div>
 
           {/* 공고 정보 */}
-          <div className="w-[346px] pt-4 flex flex-col justify-between gap-3 grow-0">
+          <div className="w-full md:w-[346px] pt-4 flex flex-col justify-between gap-3 grow-0">
             {/* 공고 시급 */}
             <div>
               <span className="text-body-1-bold text-primary-20">시급</span>
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-3 flex-wrap">
                 <span className="text-h1">{formatCurrency(hourlyPay)}원</span>
                 {increaseRate > 0 && (
-                  <span className="px-4 py-3  bg-primary-20 text-white text-body-2-bold rounded-full">
+                  <span className="px-4 py-3 bg-primary-20 text-white text-body-2-bold rounded-full">
                     기존 시급보다 {increaseRate}% ↑
                   </span>
                 )}
               </div>
             </div>
-            {/* 근무 닐짜 / 시간 */}
+            {/* 근무 날짜 / 시간 */}
             <div className="flex gap-1.5 text-body-1-regular items-center">
               <Image
                 src="/clock.svg"
@@ -67,16 +141,18 @@ export const NoticeInfo = ({ noticeDetail, onClick }: NoticeInfoProps) => {
                 alt="시간 아이콘"
                 style={{ width: "20px", height: "20px" }}
               />
-              <span className="text-gray-50 text-body-1-regular">{formatDateTime(startsAt, workhour)}</span>
+              <span className="text-gray-50 text-body-1-regular">
+                {formatDateTime(startsAt, workhour)}
+              </span>
             </div>
             {/* 주소 */}
             <div className="text-body-1-regular">
-              <div className=" flex gap-1 items-center">
+              <div className="flex gap-1 items-center">
                 <Image
                   src="/Location.svg"
                   width={20}
                   height={20}
-                  alt="시간 아이콘"
+                  alt="주소 아이콘"
                   style={{ width: "20px", height: "20px" }}
                 />
                 <span className="text-gray-50 text-body-1-regular">
@@ -91,13 +167,32 @@ export const NoticeInfo = ({ noticeDetail, onClick }: NoticeInfoProps) => {
 
             {/* 버튼 */}
             <div className="w-full flex gap-2">
-              <div className="w-full">
-                <Link href={`/owner/register-notice?mode=edit&shopId=${shop.item.id}&noticeId=${id}`}>
-                  <Button variant="outlined" className=" w-full" size="large" disabled={closed}>
-                    {closed ? "마감 완료" : "편집하기"}
+              {userRole === "employer" ? (
+                /* 사장: 편집하기 버튼 */
+                <div className="w-full">
+                  <Link href={`/owner/register-notice?mode=edit&shopId=${shop.item.id}&noticeId=${id}`}>
+                    <Button variant="outlined" className="w-full" size="large" disabled={closed}>
+                      {closed ? "마감 완료" : "편집하기"}
+                    </Button>
+                  </Link>
+                </div>
+              ) : (
+                /* 알바: 신청하기 버튼 */
+                <div className="w-full">
+                  <Button
+                    variant={buttonProps.variant}
+                    className="w-full"
+                    size="large"
+                    onClick={onApply}
+                    disabled={buttonProps.disabled || isApplying}
+                  >
+                    {isApplying ? "신청 중..." : buttonProps.text}
                   </Button>
-                </Link>
-              </div>
+                  {applicationError && (
+                    <p className="text-caption text-red-40 mt-2 text-center">{applicationError}</p>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -105,8 +200,8 @@ export const NoticeInfo = ({ noticeDetail, onClick }: NoticeInfoProps) => {
 
       {/* 공고 설명 */}
       <div className="w-full bg-gray-10 mt-6 p-8 rounded-xl">
-        <span className="text-body-1-bold text-black mb-3">공고 설명</span>
-        <p className="text-body-1-regular line-clamp-3">{description}</p>
+        <span className="text-body-1-bold text-black mb-3 block">공고 설명</span>
+        <p className="text-body-1-regular whitespace-pre-wrap">{description}</p>
       </div>
     </div>
   );

--- a/src/hooks/useJobPosts.ts
+++ b/src/hooks/useJobPosts.ts
@@ -202,9 +202,10 @@ export const useJobPosts = (options: UseJobPostsOptions = {}) => {
     setCurrentPage(1);
   }, []);
 
+  // ✅ 수정: shopId도 함께 전달
   const handlePostClick = useCallback(
     (post: PostData) => {
-      router.push(`/jobs/${post.id}`);
+      router.push(`/jobs/${post.shop.id}/${post.id}`);
     },
     [router],
   );
@@ -215,7 +216,7 @@ export const useJobPosts = (options: UseJobPostsOptions = {}) => {
 
   const handleLoginClick = useCallback(() => {
     router.push("/login");
-  }, []);
+  }, [router]);
 
   return {
     sortOption,

--- a/src/hooks/useNoticeApplication.ts
+++ b/src/hooks/useNoticeApplication.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { NoticeDetailItem } from "@/types/notice";
+import { ApplicationStatus } from "@/types/application";
+import { postNoticeApplications } from "@/api/application/ApplicationApi";
+
+interface UseNoticeApplicationReturn {
+  isApplying: boolean;
+  applicationError: string | null;
+  hasApplied: boolean;
+  applicationStatus: ApplicationStatus | null;
+  applyForNotice: () => Promise<void>;
+}
+
+/**
+ * 공고 신청 관련 로직을 관리하는 Hook
+ * 
+ * @param noticeDetail - 공고 상세 정보
+ * @returns 신청 상태 및 함수
+ */
+export const useNoticeApplication = (
+  noticeDetail: NoticeDetailItem | null
+): UseNoticeApplicationReturn => {
+  const { user } = useAuth();
+  const [isApplying, setIsApplying] = useState(false);
+  const [applicationError, setApplicationError] = useState<string | null>(null);
+  const [hasApplied, setHasApplied] = useState(false);
+  const [applicationStatus, setApplicationStatus] = useState<ApplicationStatus | null>(null);
+
+  // 초기 신청 상태 확인
+  useEffect(() => {
+    if (noticeDetail?.currentUserApplication) {
+      setHasApplied(true);
+      setApplicationStatus(noticeDetail.currentUserApplication.item.status);
+    } else {
+      setHasApplied(false);
+      setApplicationStatus(null);
+    }
+  }, [noticeDetail]);
+
+  /**
+   * 공고 신청 함수
+   */
+  const applyForNotice = useCallback(async () => {
+    if (!noticeDetail || !user) {
+      setApplicationError("로그인이 필요합니다.");
+      return;
+    }
+
+    if (user.type !== "employee") {
+      setApplicationError("알바 계정만 신청할 수 있습니다.");
+      return;
+    }
+
+    if (noticeDetail.closed) {
+      setApplicationError("마감된 공고입니다.");
+      return;
+    }
+
+    if (hasApplied) {
+      setApplicationError("이미 신청한 공고입니다.");
+      return;
+    }
+
+    setIsApplying(true);
+    setApplicationError(null);
+
+    try {
+      const response = await postNoticeApplications(
+        noticeDetail.shop.item.id,
+        noticeDetail.id
+      );
+
+      if (response) {
+        setHasApplied(true);
+        setApplicationStatus("pending");
+        alert("신청이 완료되었습니다!");
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "신청에 실패했습니다.";
+      setApplicationError(errorMessage);
+      alert(errorMessage);
+    } finally {
+      setIsApplying(false);
+    }
+  }, [noticeDetail, user, hasApplied]);
+
+  return {
+    isApplying,
+    applicationError,
+    hasApplied,
+    applicationStatus,
+    applyForNotice,
+  };
+};


### PR DESCRIPTION
# 개요

알바 공고 상세 페이지를 구현하였습니다.
공고 지원 로직을 구현하여 공고 지원 기능을 구현하였습니다.


# 변경 사항

- 공고 지원 신청하기
- localstorage로 최근에 본 공고 구현

| 상세 페이지 | 지원 완료 |
| --- | --- |
|<img width="3360" height="4300" alt="localhost_3000_login" src="https://github.com/user-attachments/assets/e7a11ddf-39b8-4dae-a234-64b6b9248e0d" />|<img width="3360" height="3554" alt="localhost_3000_jobs_24c290fd-ca7e-4f3e-a382-95ed0527d6ac_8c771da0-99b1-4398-aadc-6c306e6e3042" src="https://github.com/user-attachments/assets/56d74f41-7a59-4d19-981b-20f662487391" />|

첫 번째 공고가 7개로 보이는게 불균형하여 6개로 복구


# 추가 작업분(순서)

1. 사장 공고 상세 페이지 페이지네이션 연결
2 반응형 구현
3. 모달(토스트) 연동