### PR TITLE
[추가] 신청자 목록(테이블) 페이지네이션 추가

### DIFF
--- a/src/components/common/table/CommonTableBoss.tsx
+++ b/src/components/common/table/CommonTableBoss.tsx
@@ -34,7 +34,7 @@ const CommonTable: React.FC<TableProps> = ({ title, data, onApprove, onReject })
 
   return (
     <div className="bg-white rounded-lg shadow-sm">
-      <h2 className="text-xl font-bold text-black p-6 pb-4">{title}</h2>
+      {title ? <h2 className="text-xl font-bold text-black p-6 pb-4">{title}</h2> : null}
 
       <div className="overflow-x-auto">
         <table className="w-full table-fixed">

--- a/src/components/owner/notice/ApplicationList.tsx
+++ b/src/components/owner/notice/ApplicationList.tsx
@@ -4,6 +4,7 @@ import { useApplications } from "@/hooks/useApplications";
 import { ApplicationNoticeItem } from "@/types/application";
 import { ApplicantData } from "@/types/TablePropsTypes";
 import CommonTable from "@/components/common/table/CommonTableBoss";
+import CommonPagination from "@/components/common/pagination/CommonPagination";
 
 interface ApplicationListProps {
   shopId: string;
@@ -21,44 +22,43 @@ const convertToApplicantData = (application: ApplicationNoticeItem): ApplicantDa
 };
 
 export const ApplicationList = ({ shopId, noticeId }: ApplicationListProps) => {
-  const { applications, isLoading, error, approveApplication, rejectApplication } = useApplications(shopId, noticeId);
+  const {
+    applications,
+    isLoading,
+    error,
+    currentPage,
+    totalPages,
+    handlePageChange,
+    approveApplication,
+    rejectApplication,
+  } = useApplications(shopId, noticeId);
 
   /**
    * 신청 승인 핸들러
-   * @param applicationId - 신청 ID
    */
   const handleApprove = async (applicationId: string) => {
     try {
       await approveApplication(applicationId);
-      alert("신청 승인 완료");
+      alert("신청이 승인되었습니다.");
     } catch (err) {
-      alert("승인 처리 실패");
+      alert("승인 처리에 실패했습니다.");
     }
   };
 
   const handleReject = async (applicationId: string) => {
     try {
       await rejectApplication(applicationId);
-      alert("신청 거절 완료");
+      alert("신청이 거절되었습니다.");
     } catch (err) {
-      alert("거절 처리 실패");
+      alert("거절 처리에 실패했습니다.");
     }
   };
 
-  // 로딩
+  // 로딩 중
   if (isLoading) {
     return (
       <div className="bg-white rounded-lg shadow-sm p-12 text-center">
         <p className="text-body-1-regular text-gray-40">신청자 목록을 불러오는 중...</p>
-      </div>
-    );
-  }
-
-  // 신청자가 없을 때
-  if (applications.length === 0) {
-    return (
-      <div className="bg-white rounded-lg shadow-sm p-12 text-center">
-        <p className="text-body-1-regular text-gray-40">아직 신청자가 없습니다.</p>
       </div>
     );
   }
@@ -72,8 +72,24 @@ export const ApplicationList = ({ shopId, noticeId }: ApplicationListProps) => {
     );
   }
 
+  // 신청자가 없을 때
+  if (applications.length === 0) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-12 text-center">
+        <p className="text-body-1-regular text-gray-40">아직 신청자가 없습니다.</p>
+      </div>
+    );
+  }
+
   // ApplicationNoticeItem[] → ApplicantData[] 변환
   const applicantData: ApplicantData[] = applications.map(convertToApplicantData);
 
-  return <CommonTable title="" data={applicantData} onApprove={handleApprove} onReject={handleReject} />;
+  return (
+    <div>
+      {/* 신청자 테이블 */}
+      <CommonTable title="" data={applicantData} onApprove={handleApprove} onReject={handleReject} />
+      {/* 페이지네이션 */}
+      <CommonPagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+    </div>
+  );
 };

--- a/src/hooks/useApplications.ts
+++ b/src/hooks/useApplications.ts
@@ -4,11 +4,17 @@ import { useCallback, useEffect, useState } from "react";
 import { ApplicationNoticeItem } from "@/types/application";
 import { getNoticeApplications, putNoticeApplications } from "@/api/application/ApplicationApi";
 
+const ITEMS_PER_PAGE = 5;
+
 interface UseApplicationsData {
   applications: ApplicationNoticeItem[];
   isLoading: boolean;
   error: string | null;
+  currentPage: number;
+  totalPages: number;
+  totalCount: number;
   refetch: () => Promise<void>;
+  handlePageChange: (page: number) => void;
   approveApplication: (applicationId: string) => Promise<void>;
   rejectApplication: (applicationId: string) => Promise<void>;
 }
@@ -17,6 +23,18 @@ export const useApplications = (shopId: string | null, noticeId: string | null):
   const [applications, setApplications] = useState<ApplicationNoticeItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // 페이지네이션 상태
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+
+  // 총 페이지 수 계싼
+  const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
+
+  // offset 계산
+  const calculateOffset = (page: number): number => {
+    return (page - 1) * ITEMS_PER_PAGE;
+  };
 
   // 신청자 목록 패칭
   const fetchApplications = useCallback(async () => {
@@ -30,18 +48,32 @@ export const useApplications = (shopId: string | null, noticeId: string | null):
     setError(null);
 
     try {
-      const response = await getNoticeApplications(shopId, noticeId);
+      const offset = calculateOffset(currentPage);
+
+      const response = await getNoticeApplications(shopId, noticeId, {
+        offset,
+        limit: ITEMS_PER_PAGE,
+      });
 
       const applicationItems = response.items.map(info => info.item);
+
       setApplications(applicationItems);
+      setTotalCount(response.count);
     } catch (err) {
       const message = err instanceof Error ? err.message : "신청자 목록을 불러오는데 실패했습니다.";
       setError(message);
       setApplications([]);
+      setTotalCount(0);
     } finally {
       setIsLoading(false);
     }
-  }, [shopId, noticeId]);
+  }, [shopId, noticeId, currentPage]);
+
+  // 페이지 변경 핸들러
+  const handlePageChange = (page: number) => {
+    if (page < 1 || page > totalCount) return;
+    setCurrentPage(page);
+  };
 
   // 신청 승인
   const approveApplication = async (applicationId: string) => {
@@ -90,7 +122,11 @@ export const useApplications = (shopId: string | null, noticeId: string | null):
     applications,
     isLoading,
     error,
+    currentPage,
+    totalPages,
+    totalCount,
     refetch: fetchApplications,
+    handlePageChange,
     approveApplication,
     rejectApplication,
   };


### PR DESCRIPTION
# 개요

사장 공고 상세 페이지에서 페이지네이션을 구현하지 못해 구현했습니다.

# 변경 사항

- 신청자 목록 페이지네이션 연결

| 페이지네이션 |
| --- |
|<img width="1247" height="876" alt="스크린샷 2025-10-20 오후 11 48 01" src="https://github.com/user-attachments/assets/8f234734-a762-4a37-8f1a-5fe90b907087" />|


# 추가 작업분(순서)

1 반응형 구현
2. 모달(토스트) 연동