### PR TITLE
[수정] Login/page.tsx 빌드 오류 수정 Suspense 추가

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import nextPlugin from "@next/eslint-plugin-next";
 import tseslint from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser"; // ✅ 추가
 import prettier from "eslint-plugin-prettier";
 import eslintConfigPrettier from "eslint-config-prettier";
 
@@ -17,12 +18,14 @@ export default [
       "@next/next": nextPlugin,
     },
     languageOptions: {
+      parser: tsParser, // ✅ TypeScript 파서 지정
       parserOptions: {
         ecmaVersion: "latest",
         sourceType: "module",
         ecmaFeatures: {
           jsx: true, // ✅ JSX 문법 인식
         },
+        project: "./tsconfig.json", // ✅ 타입 기반 규칙 활성화용 (선택)
       },
     },
     rules: {
@@ -37,8 +40,6 @@ export default [
 
       /* ✅ 커스텀 규칙 */
       "@typescript-eslint/no-explicit-any": "warn",
-
-      // 🚨 ESLint가 "사용 중인 import"를 잘못 unused로 감지하는 문제 완화
       "@typescript-eslint/no-unused-vars": [
         "warn",
         {
@@ -48,10 +49,8 @@ export default [
         },
       ],
 
-      /* React / Next 관련 */
       "react-hooks/exhaustive-deps": "off",
 
-      /* ✅ Prettier 포맷 자동 적용 */
       "prettier/prettier": [
         "error",
         {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import LoginUi from "@/components/login/LoginUi";
 
 export default function LoginPage() {
-  return <LoginUi />;
+  return (
+    <Suspense fallback={<p>로그인 페이지를 불러오는 중...</p>}>
+      <LoginUi />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## 주요 수정 사항
### ESLint 설정 개선 (eslint.config.mjs)

- @typescript-eslint/parser 추가
    → TypeScript 제네릭(<T>) 및 JSX 구문 파싱 오류 해결

- languageOptions.parser 지정
    → .tsx 파일에서 TS 문법 인식 가능

- parserOptions.project 설정
    → 타입 기반 린트 규칙 활성화

### 기존 커스텀 규칙 유지 (no-explicit-any, no-unused-vars 등)

결과:
ESLint에서 발생하던 Parsing error: Unexpected token > 오류 해결
로컬 및 Vercel 빌드 환경에서 TSX 파일 정상 인식 ✅

### Suspense Boundary 추가 (src/app/(auth)/login/page.tsx)

- LoginUi 컴포넌트를 <Suspense>로 감싸도록 수정

- fallback UI(로그인 페이지를 불러오는 중...) 추가

➡️ 결과:
Next.js 빌드 시 발생하던
useSearchParams() should be wrapped in a suspense boundary 오류 해결 ✅
Vercel 빌드 및 페이지 사전 렌더링 정상화