### PR TITLE
[수정] register-shop/page 빌드 오류 수정 Suspense boundary로 감싸서 빌드 타임 오류 제거

### DIFF
--- a/src/app/(dashboard)/owner/register-shop/page.tsx
+++ b/src/app/(dashboard)/owner/register-shop/page.tsx
@@ -11,7 +11,7 @@ import { getShop } from "@/api/shop/ShopApi";
 import { ShopItem } from "@/types/shop";
 import { CATEGORY_OPTIONS, REGION_OPTIONS } from "@/constants/options";
 
-export default function NoticeRegisterPage() {
+export default function RegisterShopClient() {
   const searchParams = useSearchParams();
 
   // 쿼리 파라미터에서 mode 확인


### PR DESCRIPTION
# Vercel 빌드 중 아래와 같은 오류가 발생했습니다:

`useSearchParams() should be wrapped in a suspense boundary at page "/owner/register-shop".
Error occurred prerendering page "/owner/register-shop"

이는 useSearchParams() 훅이 서버 컴포넌트에서 직접 호출되었기 때문이며,
Next.js App Router 구조에서는 반드시 클라이언트 컴포넌트 내에서 Suspense로 감싸야 합니다.`

## 주요 변경 사항
### /app/(dashboard)/owner/register-shop/page.tsx

- useSearchParams()를 직접 호출하던 코드를 제거

- 대신 RegisterShopClient 컴포넌트를 <Suspense>로 감싸 렌더링하도록 수정

- fallback UI 추가 (가게 등록 페이지를 불러오는 중...)

import { Suspense } from "react";
import RegisterShopClient from "./RegisterShopClient";

export default function RegisterShopPage() {
  return (
    <Suspense fallback={<p>가게 등록 페이지를 불러오는 중...</p>}>
      <RegisterShopClient />
    </Suspense>
  );
}

### /app/(dashboard)/owner/register-shop/RegisterShopClient.tsx

- 기존 page.tsx 내용을 이동시켜 "use client" 선언

- useSearchParams() 훅을 클라이언트 환경에서만 실행되도록 수정

- 전체 폼 로직, 이미지 업로드, API 호출 로직은 동일 유지

➡️ useSearchParams()로 인한 빌드 타임 CSR bailout 오류 해결 ✅