### PR TITLE
[수정] 클라이언트 컴포넌트 분리, Suspense 감싸기 구조 변경

### DIFF
--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import React from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import PostsHeader from "@/components/jobs/PostsHeader";
+import PostsGrid from "@/components/jobs/PostsGrid";
+import { useJobPosts } from "@/hooks/useJobPosts";
+
+const ITEMS_PER_PAGE = 9;
+
+const SearchClient = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const keyword = searchParams.get("keyword") ?? "";
+
+  // useJobPosts 훅 사용 (keyword 전달)
+  const {
+    sortOption,
+    currentPage,
+    isFilterOpen,
+    appliedFilters,
+    posts: pageItems,
+    totalItems,
+    loading,
+    error,
+    handleSortChange,
+    handleFilterClick,
+    handleFilterClose,
+    handleFilterApply,
+    handleFilterReset,
+    handlePostClick,
+    handlePageChange,
+    fetchPosts,
+  } = useJobPosts({
+    keyword,
+    isSearchPage: true,
+  });
+
+  const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
+
+  return (
+    <div className="min-h-screen bg-gray-5">
+      <div className="max-w-[994px] mx-auto px-4 py-8">
+        <PostsHeader
+          sortOption={sortOption}
+          isFilterOpen={isFilterOpen}
+          onSortChange={handleSortChange}
+          onFilterClick={handleFilterClick}
+          onFilterClose={handleFilterClose}
+          onFilterApply={handleFilterApply}
+          onFilterReset={handleFilterReset}
+          appliedFilters={appliedFilters}
+          title={
+            <>
+              <span className="text-primary-20 font-bold">"{keyword}"</span> 검색 결과
+            </>
+          }
+          resultCount={totalItems}
+        />
+
+        <PostsGrid
+          posts={pageItems}
+          loading={loading}
+          error={error}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPostClick={handlePostClick}
+          onPageChange={handlePageChange}
+          onRetry={() => fetchPosts(currentPage, appliedFilters, sortOption)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SearchClient;

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,76 +1,10 @@
-"use client";
+import { Suspense } from "react";
+import SearchClient from "./SearchClient";
 
-import React from "react";
-import { useSearchParams, useRouter } from "next/navigation";
-import PostsHeader from "@/components/jobs/PostsHeader";
-import PostsGrid from "@/components/jobs/PostsGrid";
-import { useJobPosts } from "@/hooks/useJobPosts";
-
-const ITEMS_PER_PAGE = 9;
-
-const SearchPage = () => {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const keyword = searchParams.get("keyword") ?? "";
-
-  // useJobPosts 훅 사용 (keyword 전달)
-  const {
-    sortOption,
-    currentPage,
-    isFilterOpen,
-    appliedFilters,
-    posts: pageItems,
-    totalItems,
-    loading,
-    error,
-    handleSortChange,
-    handleFilterClick,
-    handleFilterClose,
-    handleFilterApply,
-    handleFilterReset,
-    handlePostClick,
-    handlePageChange,
-    fetchPosts,
-  } = useJobPosts({
-    keyword,
-    isSearchPage: true,
-  });
-
-  const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
-
+export default function SearchPage() {
   return (
-    <div className="min-h-screen bg-gray-5">
-      <div className="max-w-[994px] mx-auto px-4 py-8">
-        <PostsHeader
-          sortOption={sortOption}
-          isFilterOpen={isFilterOpen}
-          onSortChange={handleSortChange}
-          onFilterClick={handleFilterClick}
-          onFilterClose={handleFilterClose}
-          onFilterApply={handleFilterApply}
-          onFilterReset={handleFilterReset}
-          appliedFilters={appliedFilters}
-          title={
-            <>
-              <span className="text-primary-20 font-bold">"{keyword}"</span> 검색 결과
-            </>
-          }
-          resultCount={totalItems}
-        />
-
-        <PostsGrid
-          posts={pageItems}
-          loading={loading}
-          error={error}
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPostClick={handlePostClick}
-          onPageChange={handlePageChange}
-          onRetry={() => fetchPosts(currentPage, appliedFilters, sortOption)}
-        />
-      </div>
-    </div>
+    <Suspense fallback={<p>검색 페이지를 불러오는 중...</p>}>
+      <SearchClient />
+    </Suspense>
   );
-};
-
-export default SearchPage;
+}


### PR DESCRIPTION
수정 내용

/app/search/page.tsx에서 "use client" 제거

SearchClient.tsx 파일로 클라이언트 로직 분리

page.tsx에서 <Suspense>로 SearchClient 감싸기

-> useSearchParams() 훅이 서버 컴포넌트에서 직접 실행되던 문제를 해결했습니다.
-> Vercel 빌드 시 발생하던
useSearchParams() should be wrapped in a suspense boundary 오류 해결