### PR TITLE
[수정] 공고 신청 후 프로필 페이지에서 신첯ㅇ 내역이 즉시 표시되도록 수정 2차

### DIFF
--- a/src/api/application/ApplicationApi.ts
+++ b/src/api/application/ApplicationApi.ts
@@ -7,7 +7,7 @@ import {
 } from "@/types/application";
 import { handleApiError } from "../error/ErrorHandler";
 
-// GET - 가게의 특정 공고의 지원 목록 조회
+/** ✅ GET - 가게의 특정 공고의 지원 목록 조회 */
 export const getNoticeApplications = async (
   shopId: string,
   noticeId: string,
@@ -22,24 +22,31 @@ export const getNoticeApplications = async (
     const response = await instance.get<ApplicationNoticeResponse>(
       `/shops/${shopId}/notices/${noticeId}/applications?${newQuery}`,
     );
-
     return response.data;
   } catch (err) {
     return handleApiError(err);
   }
 };
 
-// POST - 가게의 특정 공고 지원 등록
-export const postNoticeApplications = async (shopId: string, noticeId: string): Promise<ApplicationNoticeInfo> => {
+/** ✅ POST - 가게의 특정 공고 지원 등록 (userId 포함 추가) */
+export const postNoticeApplications = async (
+  shopId: string,
+  noticeId: string,
+  userId: string,
+): Promise<ApplicationNoticeInfo> => {
   try {
-    const response = await instance.post<ApplicationNoticeInfo>(`/shops/${shopId}/notices/${noticeId}/applications`);
+    const payload = { userId }; // ✅ 신청자 정보 포함
+    const response = await instance.post<ApplicationNoticeInfo>(
+      `/shops/${shopId}/notices/${noticeId}/applications`,
+      payload,
+    );
     return response.data;
   } catch (err) {
     return handleApiError(err);
   }
 };
 
-// PUT - 가게의 특정 공고 지원 승인, 거절, 취소
+/** ✅ PUT - 가게의 특정 공고 지원 승인/거절/취소 */
 export const putNoticeApplications = async (
   shopId: string,
   noticeId: string,
@@ -57,7 +64,7 @@ export const putNoticeApplications = async (
   }
 };
 
-// GET - 유저의 지원 목록 조회
+/** ✅ GET - 유저의 지원 목록 조회 */
 export const getUserApplications = async (
   userId: string,
   query?: { offset?: number; limit?: number },

--- a/src/hooks/useNoticeApplication.ts
+++ b/src/hooks/useNoticeApplication.ts
@@ -2,10 +2,10 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "@/hooks/useAuth";
+import { useRouter } from "next/navigation";
 import { NoticeDetailItem } from "@/types/notice";
 import { ApplicationStatus } from "@/types/application";
 import { postNoticeApplications } from "@/api/application/ApplicationApi";
-import { useRouter } from "next/navigation";
 
 interface UseNoticeApplicationReturn {
   isApplying: boolean;
@@ -15,15 +15,17 @@ interface UseNoticeApplicationReturn {
   applyForNotice: () => Promise<void>;
 }
 
+/** ✅ 공고 신청 관련 훅 */
 export const useNoticeApplication = (noticeDetail: NoticeDetailItem | null): UseNoticeApplicationReturn => {
   const { user } = useAuth();
   const router = useRouter();
+
   const [isApplying, setIsApplying] = useState(false);
   const [applicationError, setApplicationError] = useState<string | null>(null);
   const [hasApplied, setHasApplied] = useState(false);
   const [applicationStatus, setApplicationStatus] = useState<ApplicationStatus | null>(null);
 
-  // 기존 신청 상태 감지
+  // ✅ 기존 신청 상태 체크
   useEffect(() => {
     if (noticeDetail?.currentUserApplication) {
       setHasApplied(true);
@@ -60,16 +62,22 @@ export const useNoticeApplication = (noticeDetail: NoticeDetailItem | null): Use
     setApplicationError(null);
 
     try {
-      // ✅ 신청 API 호출
-      const response = await postNoticeApplications(noticeDetail.shop.item.id, noticeDetail.id);
+      // ✅ userId 포함해 신청
+      const response = await postNoticeApplications(
+        noticeDetail.shop.item.id,
+        noticeDetail.id,
+        user.id, // ✅ 핵심 추가
+      );
 
       if (response) {
         setHasApplied(true);
         setApplicationStatus("pending");
         alert("신청이 완료되었습니다!");
 
-        // ✅ 신청 완료 후 프로필 페이지로 이동
-        router.push("/profile");
+        // ✅ 신청 성공 후 약간의 딜레이 후 프로필로 이동
+        setTimeout(() => {
+          router.push("/profile");
+        }, 700);
       }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "신청에 실패했습니다.";


### PR DESCRIPTION
# 🔧 Fix: 공고 신청 후 프로필 신청 내역 실시간 반영 및 UX 개선

## 📋 주요 수정 내용
- `useNoticeApplication.ts` 수정  
  - 공고 신청 시 `userId`를 함께 전송하도록 수정  
  - 신청 완료 후 `/profile` 페이지로 자동 이동하도록 개선  
- `ApplicationApi.ts` 수정  
  - `postNoticeApplications()`에서 `userId`를 요청 body에 포함  
  - 신청자가 누락되는 문제 해결  
- 신청 완료 후 프로필 페이지에서 신청 내역이 즉시 표시되도록 UX 개선  

---

## 🧩 변경 전 문제점
- 공고 신청 후 프로필 페이지에서 신청 내역이 바로 보이지 않음  
- 신청자는 DB에 저장되지 않아 `/users/{id}/applications` 결과가 비어 있음  
- 사용자가 직접 새로고침해야만 내역 확인 가능  

---

## ✅ 변경 후 개선점
- 신청 요청 시 `userId`가 함께 전달되어 DB에 정확히 저장  
- 신청 완료 후 `/profile` 페이지 자동 이동  
- 별도의 새로고침 없이 신청 내역 즉시 표시  
- 피그마 시안과 동일한 UX 구현 완료  

---

## 🧠 수정된 파일
- `src/hooks/useNoticeApplication.ts`  
  → `userId` 전송 + 신청 완료 후 `/profile` 이동 처리  
- `src/api/application/ApplicationApi.ts`  
  → 신청 요청 시 `userId` 포함하도록 수정  

---

## 🧪 테스트 결과
- [x] 알바 계정으로 공고 신청 시 정상 작동  
- [x] 신청 완료 후 자동으로 `/profile` 이동  
- [x] 신청 내역 테이블에 신규 신청 항목 바로 표시  
- [x] 승인/대기중/거절 상태 모두 정상 표시  

---

## 🎯 결과
- 공고 신청 → alert(신청 완료) → `/profile` 자동 이동  
- 신청 내역 테이블에 신규 신청 내역 즉시 반영  
- 자연스럽고 직관적인 사용자 경험 달성 ✅  