### PR TITLE
[수정] 프로필 페이지 스타일, 신청 내역 오류 수정 / 전체적인 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.12.2",
+        "lucide-react": "^0.546.0",
         "next": "15.5.4",
         "react": "19.1.0",
         "react-datepicker": "^8.7.0",
@@ -4574,6 +4575,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.546.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.546.0.tgz",
+      "integrity": "sha512-Z94u6fKT43lKeYHiVyvyR8fT7pwCzDu7RyMPpTvh054+xahSgj4HFQ+NmflvzdXsoAjYGdCguGaFKYuvq0ThCQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.12.2",
+    "lucide-react": "^0.546.0",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-datepicker": "^8.7.0",

--- a/src/app/profile/detail/page.tsx
+++ b/src/app/profile/detail/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Button from "@/components/common/button";
 import { AuthLoginApi } from "@/contexts/AuthLoginApi";
 import { getProfile, getApplications } from "@/api/profile/profileApi";
+import { MapPin, Phone } from "lucide-react";
 
 interface ProfileData {
   name: string;
@@ -16,10 +17,10 @@ interface ProfileData {
 interface ApplicationData {
   id: number;
   shopName: string;
-  noticeTitle: string;
+  startsAt: string;
+  workhour: number;
+  hourlyPay: number;
   status: "pending" | "accepted" | "rejected";
-  createdAt: string;
-  hourlyPay?: number;
 }
 
 export default function ProfileDetailPage() {
@@ -27,6 +28,9 @@ export default function ProfileDetailPage() {
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [applications, setApplications] = useState<ApplicationData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const ITEMS_PER_PAGE = 5;
 
   useEffect(() => {
     const restoredUser = AuthLoginApi.restoreUserFromStorage();
@@ -41,17 +45,8 @@ export default function ProfileDetailPage() {
   const fetchData = async (id: string) => {
     try {
       const [profileRes, appRes] = await Promise.all([getProfile(id), getApplications(id)]);
-
-      setProfile({
-        name: profileRes?.name ?? "",
-        phone: profileRes?.phone ?? "",
-        address: profileRes?.address ?? "",
-        bio: profileRes?.bio ?? "",
-      });
-
-      // getApplications에서 이미 배열 반환하므로 그대로 사용
+      setProfile(profileRes);
       setApplications(appRes ?? []);
-      console.log("📦 신청 내역 데이터:", appRes);
     } catch (error) {
       console.error("❌ 데이터 로드 실패:", error);
     } finally {
@@ -59,108 +54,142 @@ export default function ProfileDetailPage() {
     }
   };
 
-  if (loading) return <p className="text-center mt-10">불러오는 중...</p>;
+  const formatDateTime = (startsAt: string, workhour: number) => {
+    const start = new Date(startsAt);
+    if (isNaN(start.getTime())) return "-";
 
-  if (!profile)
-    return (
-      <main className="min-h-screen w-full max-w-[957px] mx-auto px-5 pt-[40px] pb-[120px]">
-        <section className="border border-gray-20 rounded-[8px] bg-white py-[56px] px-[24px] text-center shadow">
-          <p className="text-body-1-regular text-gray-50 mb-[28px]">
-            내 프로필을 등록하고 원하는 가게에 지원해 보세요.
-          </p>
-          <Button
-            variant="primary"
-            size="large"
-            className="w-[240px] h-[47px] mx-auto"
-            onClick={() => router.push("/profile/register")}
-          >
-            내 프로필 등록하기
-          </Button>
-        </section>
-      </main>
-    );
+    const end = new Date(start.getTime() + workhour * 60 * 60 * 1000);
+    const date = start.toISOString().split("T")[0];
+    const startTime = start.toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", hour12: false });
+    const endTime = end.toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", hour12: false });
+
+    return `${date} ${startTime} ~ ${endTime} (${workhour}시간)`;
+  };
+
+  const totalPages = Math.ceil(applications.length / ITEMS_PER_PAGE);
+  const paginatedApps = applications.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
+
+  const handlePageChange = (page: number) => {
+    if (page < 1 || page > totalPages) return;
+    setCurrentPage(page);
+  };
+
+  if (loading) return <p className="text-center mt-10">불러오는 중...</p>;
 
   return (
     <main className="min-h-screen w-full max-w-[957px] mx-auto px-5 pt-[40px] pb-[120px]">
+      {/* 🧾 내 프로필 */}
       <h1 className="text-h2 font-bold mb-[24px] text-black">내 프로필</h1>
 
-      {/* 프로필 카드 */}
-      <section className="border border-gray-20 rounded-[8px] bg-[#FFF5F5] py-[32px] px-[24px] mb-[80px] shadow-sm">
-        <div className="flex flex-col gap-[8px] text-gray-900">
-          <div className="flex items-center justify-between mb-[8px]">
-            <p className="text-h3 font-semibold text-red-500">이름</p>
+      {profile && (
+        <section className="border border-gray-20 rounded-[12px] bg-[#FFF5F5] py-[32px] px-[24px] mb-[80px] shadow-sm">
+          <div className="flex items-start justify-between">
+            <div className="flex flex-col gap-[6px]">
+              <p className="text-red-500 text-body-2-semibold">이름</p>
+              <h2 className="text-h3 font-bold text-black">{profile.name}</h2>
+              <p className="flex items-center gap-2 text-gray-500 text-body-2-regular mt-2">
+                <Phone className="w-4 h-4 text-gray-400" />
+                {profile.phone}
+              </p>
+              <p className="flex items-center gap-2 text-gray-500 text-body-2-regular">
+                <MapPin className="w-4 h-4 text-gray-400" />
+                {profile.address}
+              </p>
+              <p className="text-gray-800 text-body-2-regular mt-2">{profile.bio}</p>
+            </div>
+
             <Button
               variant="outlined"
               size="small"
               onClick={() => router.push("/profile/edit")}
-              className="px-[12px] py-[4px] text-gray-80 border-gray-30"
+              className="px-[16px] py-[6px] text-red-500 border-red-500 hover:bg-red-50"
             >
               편집하기
             </Button>
           </div>
+        </section>
+      )}
 
-          <p className="text-body-1-semibold text-black">{profile.name}</p>
-          <p className="text-body-2-regular text-gray-70">📞 {profile.phone}</p>
-          <p className="text-body-2-regular text-gray-70">📍 {profile.address}</p>
-          <p className="text-body-1-regular text-gray-80 mt-[8px] leading-relaxed">{profile.bio}</p>
-        </div>
-      </section>
+      {/* 📄 신청 내역 */}
+      <h2 className="text-h2 font-bold mb-[24px] text-black">신청 내역</h2>
 
-      {/* 신청 내역 */}
-      <section>
-        <h2 className="text-h3 font-bold mb-[24px] text-black">신청 내역</h2>
-
-        {applications.length > 0 ? (
-          <div className="border border-gray-20 rounded-[8px] bg-white shadow-sm overflow-hidden">
-            <table className="w-full border-collapse text-center">
-              <thead className="bg-[#FFF5F5]">
-                <tr className="text-body-2-semibold text-gray-800">
-                  <th className="py-4 px-6 text-left">가게</th>
-                  <th className="py-4 px-6">일자</th>
-                  <th className="py-4 px-6">시급</th>
-                  <th className="py-4 px-6">상태</th>
+      {applications.length > 0 ? (
+        <div className="border border-gray-20 rounded-[8px] bg-white shadow-sm overflow-hidden">
+          <table className="w-full border-collapse text-center">
+            <thead className="bg-[#FFF5F5]">
+              <tr className="text-body-2-semibold text-gray-800">
+                <th className="py-4 px-6 text-left">가게</th>
+                <th className="py-4 px-6">근무일자</th>
+                <th className="py-4 px-6">시급</th>
+                <th className="py-4 px-6">상태</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paginatedApps.map(app => (
+                <tr key={app.id} className="border-t border-gray-10 hover:bg-gray-50 transition">
+                  <td className="py-4 px-6 text-left text-gray-900 font-medium">{app.shopName}</td>
+                  <td className="py-4 px-6 text-gray-700">{formatDateTime(app.startsAt, app.workhour)}</td>
+                  <td className="py-4 px-6 text-gray-900">{app.hourlyPay.toLocaleString()}원</td>
+                  <td className="py-4 px-6">
+                    <span
+                      className={`inline-block px-3 py-1 rounded-full text-sm font-medium ${
+                        app.status === "accepted"
+                          ? "bg-[#E5F1FF] text-[#2186FF]" // 승인 완료
+                          : app.status === "pending"
+                            ? "bg-[#E7F6E7] text-[#2EB62C]" // 대기중
+                            : "bg-[#FFE7E7] text-[#F04438]" // 거절
+                      }`}
+                    >
+                      {app.status === "accepted" ? "승인 완료" : app.status === "pending" ? "대기중" : "거절"}
+                    </span>
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {applications.map(app => (
-                  <tr key={app.id} className="border-t border-gray-10 hover:bg-gray-50 transition">
-                    <td className="py-4 px-6 text-left text-gray-900">{app.shopName}</td>
-                    <td className="py-4 px-6 text-gray-700">
-                      {new Date(app.createdAt).toLocaleDateString("ko-KR")} 10:00 ~ 12:00 (2시간)
-                    </td>
-                    <td className="py-4 px-6 text-gray-900">{(app.hourlyPay ?? 15000).toLocaleString()}원</td>
-                    <td className="py-4 px-6">
-                      <span
-                        className={`inline-block px-3 py-1 rounded-full text-sm font-medium ${
-                          app.status === "accepted"
-                            ? "bg-blue-100 text-blue-700"
-                            : app.status === "pending"
-                              ? "bg-green-100 text-green-700"
-                              : "bg-red-100 text-red-700"
-                        }`}
-                      >
-                        {app.status === "accepted" ? "승인 완료" : app.status === "pending" ? "대기중" : "거절"}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        ) : (
-          <div className="border border-gray-20 rounded-[8px] bg-gray-0 py-[56px] px-[24px] text-center shadow">
-            <p className="text-body-1-regular text-gray-50 mb-[28px]">아직 신청 내역이 없어요.</p>
-            <Button
-              variant="primary"
-              size="large"
-              className="w-[240px] h-[47px] mx-auto"
-              onClick={() => router.push("/jobs")}
+              ))}
+            </tbody>
+          </table>
+
+          {/* 페이지네이션 */}
+          <div className="flex justify-center items-center gap-2 py-5 bg-white">
+            <button
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+              className="px-3 py-1 text-gray-500 disabled:text-gray-300"
             >
-              공고 보러가기
-            </Button>
+              &lt;
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => (
+              <button
+                key={page}
+                onClick={() => handlePageChange(page)}
+                className={`w-8 h-8 rounded-md font-medium ${
+                  currentPage === page ? "bg-[#EA3C12] text-white" : "text-gray-700 hover:bg-gray-100"
+                }`}
+              >
+                {page}
+              </button>
+            ))}
+            <button
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              className="px-3 py-1 text-gray-500 disabled:text-gray-300"
+            >
+              &gt;
+            </button>
           </div>
-        )}
-      </section>
+        </div>
+      ) : (
+        <div className="border border-gray-20 rounded-[8px] bg-gray-0 py-[56px] px-[24px] text-center shadow">
+          <p className="text-body-1-regular text-gray-50 mb-[28px]">아직 신청 내역이 없어요.</p>
+          <Button
+            variant="primary"
+            size="large"
+            className="w-[240px] h-[47px] mx-auto"
+            onClick={() => router.push("/jobs")}
+          >
+            공고 보러가기
+          </Button>
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
작업 내용
1️⃣ 프로필 상세 페이지 상단 카드 추가

피그마 디자인에 맞춰 연한 분홍색 카드 형태의 프로필 영역 구현

이름, 전화번호, 주소, 자기소개, 편집 버튼 포함

lucide-react 아이콘(Phone, MapPin) 추가로 시각적 가독성 강화

<section className="bg-[#FFF5F5] rounded-[12px] py-[32px] px-[24px] shadow-sm">
  ...
  <Phone />
  <MapPin />
</section>

2️⃣ 신청 내역 테이블 구조 개선

컬럼 구조: 가게 / 근무일자 / 시급 / 상태

startsAt, workhour 기반으로 날짜·시간 포맷 처리

상태값(accepted, pending, rejected)에 따라 뱃지 색상 지정

승인 완료 → 파랑 (#2186FF)

대기중 → 초록 (#2EB62C)

거절 → 빨강 (#F04438)

app.status === "accepted"
  ? "bg-[#E5F1FF] text-[#2186FF]"
  : app.status === "pending"
  ? "bg-[#E7F6E7] text-[#2EB62C]"
  : "bg-[#FFE7E7] text-[#F04438]"

3️⃣ 페이지네이션 추가

한 페이지당 5개 데이터 표시

현재 페이지는 주황색(primary-20 / #EA3C12)으로 강조

이전 / 다음 버튼 비활성화 처리

중앙 정렬로 피그마 디자인과 동일한 구성

4️⃣ 기타 수정 사항

lucide-react 설치

npm install lucide-react


TypeScript 에러(ts2307) 해결

tsconfig.json에 skipLibCheck 옵션으로 타입 검사 범위 조정