### PR TITLE
[수정] ProfileRegisterPage 린트 에러 해결 및 접근성 개선

### DIFF
--- a/src/app/profile/register/page.tsx
+++ b/src/app/profile/register/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 export const dynamic = "force-static";
+
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Button from "@/components/common/button";
@@ -10,7 +11,12 @@ import { saveProfile } from "@/api/profile/profileApi";
 
 export default function ProfileRegisterPage() {
   const router = useRouter();
-  const [form, setForm] = useState({ name: "", phone: "", region: "", intro: "" });
+  const [form, setForm] = useState({
+    name: "",
+    phone: "",
+    region: "",
+    intro: "",
+  });
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 
@@ -50,6 +56,7 @@ export default function ProfileRegisterPage() {
         <button
           onClick={() => router.push("/profile")}
           className="absolute right-0 top-0 text-h2 text-gray-50 hover:text-black"
+          aria-label="닫기"
         >
           ✕
         </button>
@@ -59,9 +66,13 @@ export default function ProfileRegisterPage() {
       <form onSubmit={handleSubmit} className="flex flex-col gap-[32px]">
         {/* 이름 / 연락처 / 선호지역 */}
         <div className="grid grid-cols-1 tablet:grid-cols-3 gap-[24px]">
+          {/* 이름 */}
           <div className="flex flex-col">
-            <label className="text-body-1-regular text-black mb-[8px]">이름*</label>
+            <label htmlFor="name" className="text-body-1-regular text-black mb-[8px]">
+              이름*
+            </label>
             <input
+              id="name"
               name="name"
               value={form.name}
               onChange={handleChange}
@@ -70,9 +81,13 @@ export default function ProfileRegisterPage() {
             />
           </div>
 
+          {/* 연락처 */}
           <div className="flex flex-col">
-            <label className="text-body-1-regular text-black mb-[8px]">연락처*</label>
+            <label htmlFor="phone" className="text-body-1-regular text-black mb-[8px]">
+              연락처*
+            </label>
             <input
+              id="phone"
               name="phone"
               value={form.phone}
               onChange={handleChange}
@@ -81,9 +96,13 @@ export default function ProfileRegisterPage() {
             />
           </div>
 
+          {/* 선호 지역 */}
           <div className="flex flex-col">
-            <label className="text-body-1-regular text-black mb-[8px]">선호 지역</label>
-            <select //속성 이름 없어도 문제없는지? 린트에러가 나고있어서요 - 찬민
+            <label htmlFor="region" className="text-body-1-regular text-black mb-[8px]">
+              선호 지역
+            </label>
+            <select
+              id="region"
               name="region"
               value={form.region}
               onChange={handleChange}
@@ -91,7 +110,7 @@ export default function ProfileRegisterPage() {
             >
               <option value="">선택</option>
               {REGION_OPTIONS.map(r => (
-                <option key={r.value} value={r.label}>
+                <option key={r.value} value={r.value}>
                   {r.label}
                 </option>
               ))}
@@ -99,10 +118,13 @@ export default function ProfileRegisterPage() {
           </div>
         </div>
 
-        {/* 소개 */}
+        {/* 자기소개 */}
         <div>
-          <label className="text-body-1-regular text-black mb-[8px] block">소개</label>
+          <label htmlFor="intro" className="text-body-1-regular text-black mb-[8px] block">
+            소개
+          </label>
           <textarea
+            id="intro"
             name="intro"
             value={form.intro}
             onChange={handleChange}
@@ -111,7 +133,7 @@ export default function ProfileRegisterPage() {
           />
         </div>
 
-        {/* 버튼 */}
+        {/* 등록 버튼 */}
         <div className="text-center">
           <Button type="submit" variant="primary" size="large" className="w-[240px] h-[47px] mx-auto">
             등록하기


### PR DESCRIPTION
## 📌 작업 개요  
`ProfileRegisterPage` 컴포넌트의 린트 에러를 해결하고, 접근성과 코드 가독성을 개선했습니다.

---

## ✨ 주요 변경 사항

### 🔹 린트 에러 해결  
- 불필요한 주석(`//속성 이름 없어도 문제없는지? 린트에러가 나고있어서요 - 찬민`) 제거  
- `label` 태그에 `htmlFor` 속성 추가 (ESLint 규칙 준수)  
- `id` 속성 부여로 각 input/select 연결

### 🔹 접근성(A11y) 개선  
- `aria-label="닫기"` 속성 추가  
- form 요소에 명확한 label 연결로 스크린리더 호환성 강화

### 🔹 코드 구조 정리  
- `REGION_OPTIONS` 사용 시 `r.value` → `r.label` 혼용 문제 해결  
- `<select>`의 `option` 값 명확히 지정 (`value={r.value}`)  
- 불필요한 주석 제거 및 구조 정돈  
- 변수/함수 선언부 간 간격 일관화

### 🔹 디자인 및 기능 유지  
- 기존 피그마 폼 디자인 및 UX 유지  
- 등록 완료 시 모달 → `/profile/detail` 이동 로직 유지  
- 스타일 변경 없음 (`TailwindCSS` 클래스 유지)

---

## 🧩 수정 후 코드 일부 예시

```tsx
<label htmlFor="region" className="text-body-1-regular text-black mb-[8px]">
  선호 지역
</label>
<select
  id="region"
  name="region"
  value={form.region}
  onChange={handleChange}
  className="border border-gray-20 rounded-[6px] px-[16px] h-[52px] bg-white focus:outline-none"
>
  <option value="">선택</option>
  {REGION_OPTIONS.map(r => (
    <option key={r.value} value={r.value}>
      {r.label}
    </option>
  ))}
</select>
