### PR TITLE
[수정] 알림 버튼 경로 변경

### DIFF
--- a/src/app/profile/register/page.tsx
+++ b/src/app/profile/register/page.tsx
@@ -98,11 +98,8 @@ export default function ProfileRegisterPage() {
 
           {/* 선호 지역 */}
           <div className="flex flex-col">
+            {/* 중복되는 select 삭제 */}
             <label className="text-body-1-regular text-black mb-[8px]">선호 지역</label>
-            <select //속성 이름 없어도 문제없는지? 린트에러가 나고있어서요 - 찬민
-            <label htmlFor="region" className="text-body-1-regular text-black mb-[8px]">
-              선호 지역
-            </label>
             <select
               id="region"
               name="region"

--- a/src/components/common/gnb/notification/NotificationDropdown.tsx
+++ b/src/components/common/gnb/notification/NotificationDropdown.tsx
@@ -28,8 +28,8 @@ const NotificationDropDown = ({ onClose }: DropdownProps) => {
         throw new Error("읽은 알림을 처리하는데 실패했습니다.");
       }
     }
-    router.push(notification.notice.href);
 
+    router.push(`/jobs/${notification.shop.item.id}/${notification.notice.item.id}`);
     onClose();
   };
 


### PR DESCRIPTION
# 개요

알림 카드에 연동된 URL 변경하였습니다.

# 변경사항

`router.push(notification.notice.href);` -> `router.push(`/jobs/${notification.shop.item.id}/${notification.notice.item.id}`);`

 거절이나 승인된 알림을 누르면 신청한 공고 상세 페이지로 가게끔 변경했습니다