### PR TITLE
[수정] 알림 카드 href 변경

### DIFF
--- a/src/components/common/gnb/notification/NotificationDropdown.tsx
+++ b/src/components/common/gnb/notification/NotificationDropdown.tsx
@@ -28,8 +28,8 @@ const NotificationDropDown = ({ onClose }: DropdownProps) => {
         throw new Error("읽은 알림을 처리하는데 실패했습니다.");
       }
     }
-    router.push(notification.notice.href);
 
+    router.push(`/jobs/${notification.shop.item.id}/${notification.notice.item.id}`);
     onClose();
   };
 


### PR DESCRIPTION
# 개요

알림 카드에 연동된 URL 변경하였습니다.

# 변경사항

`router.push(notification.notice.href);` -> `router.push(`/jobs/${notification.shop.item.id}/${notification.notice.item.id}`);`

 거절이나 승인된 알림을 누르면 신청한 공고 상세 페이지로 가게끔 변경했습니다